### PR TITLE
Remove reference to develop in workflow.

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -3,7 +3,6 @@ name: Build Test and Deploy
 on:
   push:
     branches:
-      - 'develop'
       - 'master'
 
 permissions:


### PR DESCRIPTION
Hello @DGaffney ! This change cleans up the workflow for image build and upload. We're no longer using develop branches for QA deployments.