### PR TITLE
Update docker-compose.yml moving `args` under `build`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ version: '3.9'
 services:
   app:
     platform: linux/amd64
-    build: .
+    build:
+      args:
+        - PRESTO_PORT=${PRESTO_PORT}
     env_file:
       - ./.env_file
     depends_on:
@@ -14,8 +16,7 @@ services:
       - ./:/app
     ports:
       - "${PRESTO_PORT}:${PRESTO_PORT}"
-    args:
-      - PRESTO_PORT=${PRESTO_PORT}
+
   elasticmq:
     image: softwaremill/elasticmq
     hostname: presto-elasticmq


### PR DESCRIPTION
fixing `services.app additional property args is not allowed` error while docker-compose build