### PR TITLE
CV2-3852 fix queue prefix logic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,10 @@ version: '3.9'
 services:
   app:
     platform: linux/amd64
-    build: .
+    build: 
+      context: .
+      args:
+        - PRESTO_PORT=${PRESTO_PORT}
     env_file:
       - ./.env_file
     depends_on:
@@ -12,9 +15,6 @@ services:
       - elasticmq
     volumes:
       - ./:/app
-      - "${PRESTO_PORT}:${PRESTO_PORT}"
-    args:
-      - PRESTO_PORT=${PRESTO_PORT}
   elasticmq:
     image: softwaremill/elasticmq
     hostname: presto-elasticmq

--- a/lib/http.py
+++ b/lib/http.py
@@ -6,6 +6,7 @@ from httpx import HTTPStatusError
 from fastapi import FastAPI, Request
 from pydantic import BaseModel
 from lib.queue.worker import QueueWorker
+from lib.queue.queue import Queue
 from lib.logger import logger
 from lib import schemas
 from lib.sentry import sentry_sdk
@@ -32,7 +33,7 @@ async def post_url(url: str, params: dict) -> Dict[str, Any]:
 @app.post("/process_item/{process_name}")
 def process_item(process_name: str, message: Dict[str, Any]):
     logger.info(message)
-    queue_prefix = get_setting("", "QUEUE_PREFIX").replace(".", "__")
+    queue_prefix = Queue.get_queue_prefix()
     queue = QueueWorker.create(process_name)
     queue.push_message(f"{queue_prefix}{process_name}", schemas.Message(body=message))
     return {"message": "Message pushed successfully", "queue": process_name, "body": message}

--- a/lib/queue/processor.py
+++ b/lib/queue/processor.py
@@ -14,8 +14,7 @@ class QueueProcessor(Queue):
         Instantiate a queue. Must pass input_queue_name, output_queue_name, and batch_size.
         Pulls settings and then inits instance.
         """
-        queue_prefix = get_setting("", "QUEUE_PREFIX").replace(".", "__")
-        input_queue_name = queue_prefix+get_setting(input_queue_name, "MODEL_NAME").replace(".", "__")
+        input_queue_name = Queue.get_queue_name(input_queue_name)
         logger.info(f"Starting queue with: ('{input_queue_name}', {batch_size})")
         return QueueProcessor(input_queue_name, batch_size)
 

--- a/lib/queue/queue.py
+++ b/lib/queue/queue.py
@@ -5,7 +5,7 @@ import os
 import boto3
 import botocore
 
-from lib.helpers import get_environment_setting
+from lib.helpers import get_setting, get_environment_setting
 from lib.logger import logger
 from lib import schemas
 SQS_MAX_BATCH_SIZE = 10
@@ -15,6 +15,14 @@ class Queue:
         Start a specific queue - must pass input_queue_name.
         """
         self.sqs = self.get_sqs()
+
+    @staticmethod
+    def get_queue_prefix():
+        return (get_environment_setting("QUEUE_PREFIX") or "").replace(".", "__")
+
+    @staticmethod
+    def get_queue_name(input_queue_name):
+        return Queue.get_queue_prefix()+get_setting(input_queue_name, "MODEL_NAME").replace(".", "__")
 
     def store_queue_map(self, all_queues: List[boto3.resources.base.ServiceResource]) -> Dict[str, boto3.resources.base.ServiceResource]:
         """

--- a/lib/queue/worker.py
+++ b/lib/queue/worker.py
@@ -12,8 +12,7 @@ class QueueWorker(Queue):
         Instantiate a queue worker. Must pass input_queue_name.
         Pulls settings and then inits instance.
         """
-        queue_prefix = get_setting("", "QUEUE_PREFIX").replace(".", "__")
-        input_queue_name = queue_prefix+get_setting(input_queue_name, "MODEL_NAME").replace(".", "__")
+        input_queue_name = Queue.get_queue_name(input_queue_name)
         output_queue_name = f"{input_queue_name}_output"
         logger.info(f"Starting queue with: ('{input_queue_name}', '{output_queue_name}')")
         return QueueWorker(input_queue_name, output_queue_name)


### PR DESCRIPTION
References 3852 in Jira - 

During the last deploy we had to rush in a fix to presto that would add a `QUEUE_PREFIX` environment variable so that we could have differently named SQS queues for the QA and Live environments. This came into conflict with the existing way we check for environment settings, where we opt to use a local value first by default. Our tests were broken as a result, since there's no local QUEUE_PREFIX supplied by default. I went ahead and added fixes to unify the calling for this `QUEUE_PREFIX` setting, and set it up to use the environment variable for it by default. This should fix the issues and clean up the incongruencies we had this week.