### PR TITLE
Adding `ports` to `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - elasticmq
     volumes:
       - ./:/app
+    ports:
+      - "${PRESTO_PORT}:${PRESTO_PORT}"
   elasticmq:
     image: softwaremill/elasticmq
     hostname: presto-elasticmq


### PR DESCRIPTION
adding 
```
    ports:
      - "${PRESTO_PORT}:${PRESTO_PORT}"
```
to `docker-compose.yml` to fix missing ports error