### PR TITLE
First attempt at tag based deploy workflow.

### DIFF
--- a/.github/workflows/ci-tag-deploy.yml
+++ b/.github/workflows/ci-tag-deploy.yml
@@ -1,0 +1,87 @@
+name: Live Deploy
+
+on:
+  push:
+    # Pattern matched against refs/tags
+    tags:        
+      - '*'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  live-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Kick off Terraform deploy in sysops/
+      id: sysops-deploy
+      run: |
+        curl \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.SYSOPS_RW_GITHUB_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/meedan/sysops/actions/workflows/deploy_${{ github.event.repository.name }}.yml/dispatches \
+          -d '{"ref": "master", "inputs": {"git_tag": "${{ github.ref_name }}"}}'
+
+    - name: Send GitHub Action trigger data to Slack workflow on success
+      id: slack-api-notify-success
+      if: ${{ success() }}
+      uses: slackapi/slack-github-action@v1.23.0
+      with:
+         payload: |
+          {
+            "attachments": [
+              {
+                "color": "#00FF00",
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "Kicked off by: ${{ github.triggering_actor }}\nWorkflow: https://github.com/meedan/presto/actions/runs/${{ github.run_id }}"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "Presto Live Deploy:\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.CHECK_DEV_BOTS_SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+    - name: Send GitHub Action trigger data to Slack workflow on failure
+      id: slack-api-notify-failure
+      if: ${{ failure() }}
+      uses: slackapi/slack-github-action@v1.23.0
+      with:
+         payload: |
+          {
+            "attachments": [
+              {
+                "color": "#FF0000",
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "Presto Live Deploy failed\nWorkflow: https://github.com/meedan/presto/actions/runs/${{ github.run_id }}"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.ITS_BOTS_SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+


### PR DESCRIPTION
This is a draft attempt at a tag based Live deployment workflow for Presto.

One remaining question mark is how to tie the image to the tag, as we currently have `master` and specific revision `sha`s as identifier options; no tag names.

We could just deploy master when tagged, as it should always be the latest that we deploy? But that's hacky and will have unintended side effects at some point in the future. I'll look at this again once I've got a bit more brain to apply...