### PR TITLE
Use default role based access for S3 instead of explicit credentials.

### DIFF
--- a/lib/s3.py
+++ b/lib/s3.py
@@ -8,16 +8,11 @@ def upload_file_to_s3(bucket: str, filename: str):
     Generic upload helper for s3. Could be moved over to helpers folder...
     """
     s3_url = os.getenv('S3_ENDPOINT')
-    access_key = os.getenv('AWS_ACCESS_KEY_ID')
-    secret_key = os.getenv('AWS_SECRET_ACCESS_KEY')
     region = os.getenv('AWS_DEFAULT_REGION')
     secure = s3_url and s3_url.startswith('https')
     # Set up the S3 client
     s3_client = boto3.client('s3',
         endpoint_url=s3_url,
-        aws_access_key_id=access_key,
-        aws_secret_access_key=secret_key,
-        config=Config(signature_version='s3v4'),
         region_name=region,
         use_ssl=secure)
     # Extract the file name from the local file path


### PR DESCRIPTION
Use default role based access for S3 instead of explicit credentials.