### PR TITLE
CV2-4606 add retry count to spec

### DIFF
--- a/lib/queue/worker.py
+++ b/lib/queue/worker.py
@@ -142,6 +142,6 @@ class QueueWorker(Queue):
                 capture_custom_message("Message exceeded max retries. Moving to DLQ.", 'info', {"message_body": message_body})
                 self.push_to_dead_letter_queue(schemas.parse_message(message_body))
             else:
-                message_body['retry_count'] = retry_count
                 updated_message = schemas.parse_message(message_body)
+                updated_message.retry_count = retry_count
                 self.push_message(self.input_queue_name, updated_message)

--- a/lib/schemas.py
+++ b/lib/schemas.py
@@ -23,6 +23,7 @@ class GenericItem(BaseModel):
 class Message(BaseModel):
     body: GenericItem
     model_name: str
+    retry_count: int = 0
 
 def parse_message(message_data: Dict) -> Message:
     body_data = message_data['body']

--- a/test/lib/queue/test_queue.py
+++ b/test/lib/queue/test_queue.py
@@ -113,7 +113,7 @@ class TestQueueWorker(unittest.TestCase):
         # Call push_message
         returned_message = self.queue.push_message(self.queue_name_output, message_to_push)
         # Check if the message was correctly serialized and sent
-        self.mock_output_queue.send_message.assert_called_once_with(MessageBody='{"body": {"id": 1, "callback_url": "http://example.com", "url": null, "text": "This is a test", "raw": {}, "parameters": {}, "result": {"hash_value": null}}, "model_name": "mean_tokens__Model"}')
+        self.mock_output_queue.send_message.assert_called_once_with(MessageBody='{"body": {"id": 1, "callback_url": "http://example.com", "url": null, "text": "This is a test", "raw": {}, "parameters": {}, "result": {"hash_value": null}}, "model_name": "mean_tokens__Model", "retry_count": 0}')
         self.assertEqual(returned_message, message_to_push)
 
     def test_push_to_dead_letter_queue(self):
@@ -121,7 +121,7 @@ class TestQueueWorker(unittest.TestCase):
         # Call push_to_dead_letter_queue
         self.queue.push_to_dead_letter_queue(message_to_push)
         # Check if the message was correctly serialized and sent to the DLQ
-        self.mock_dlq_queue.send_message.assert_called_once_with(MessageBody='{"body": {"id": 1, "callback_url": "http://example.com", "url": null, "text": "This is a test", "raw": {}, "parameters": {}, "result": {"hash_value": null}}, "model_name": "mean_tokens__Model"}')
+        self.mock_dlq_queue.send_message.assert_called_once_with(MessageBody='{"body": {"id": 1, "callback_url": "http://example.com", "url": null, "text": "This is a test", "raw": {}, "parameters": {}, "result": {"hash_value": null}}, "model_name": "mean_tokens__Model", "retry_count": 0}')
 
     def test_increment_message_error_counts_exceed_max_retries(self):
         message_body = {


### PR DESCRIPTION
Right now when we increment retry count it actually doesn't do anything, because it silently gets dropped when parsing the message into the schema - we need this in order to properly increment and ultimately fail