### PR TITLE
CV2-4713 disable opentelemetry temporarily

### DIFF
--- a/lib/queue/worker.py
+++ b/lib/queue/worker.py
@@ -13,7 +13,7 @@ from lib.helpers import get_environment_setting
 from lib.telemetry import OpenTelemetryExporter
 
 TIMEOUT_SECONDS = int(os.getenv("WORK_TIMEOUT_SECONDS", "60"))
-OPEN_TELEMETRY_EXPORTER = OpenTelemetryExporter(service_name="QueueWorkerService", local_debug=False)
+# OPEN_TELEMETRY_EXPORTER = OpenTelemetryExporter(service_name="QueueWorkerService", local_debug=False)
 
 class QueueWorker(Queue):
     @classmethod
@@ -105,42 +105,42 @@ class QueueWorker(Queue):
                 future = executor.submit(model.respond, args)
                 result = future.result(timeout=timeout_seconds)
                 execution_time = time.time() - start_time
-                QueueWorker.log_execution_time(model.model_name, execution_time)
-                QueueWorker.log_execution_status(model.model_name, "successful_message_response")
+                # QueueWorker.log_execution_time(model.model_name, execution_time)
+                # QueueWorker.log_execution_status(model.model_name, "successful_message_response")
                 return result, True
         except TimeoutError:
             error_message = "Model respond timeout exceeded."
             QueueWorker.log_and_handle_error(error_message)
-            QueueWorker.log_execution_status(model.model_name, "timeout_message_response")
+            # QueueWorker.log_execution_status(model.model_name, "timeout_message_response")
             return [], False
         except Exception as e:
             QueueWorker.log_and_handle_error(str(e))
-            QueueWorker.log_execution_status(model.model_name, "error_message_response")
+            # QueueWorker.log_execution_status(model.model_name, "error_message_response")
             return [], False
 
-    @staticmethod
-    def log_execution_time(func_name: str, execution_time: float):
-        """
-        Logs the execution time of a function to OpenTelemetry.
-
-        Parameters:
-        - func_name (str): The name of the function that was executed.
-        - execution_time (float): The time taken to execute the function.
-        """
-        logger.debug(f"Function {func_name} executed in {execution_time:.2f} seconds.")
-        OPEN_TELEMETRY_EXPORTER.log_execution_time(func_name, execution_time)
-
-    @staticmethod
-    def log_execution_status(func_name: str, logging_metric: str):
-        """
-        Logs the execution of a function to CloudWatch.
-
-        Parameters:
-        - func_name (str): The name of the function that was executed.
-        - logging_metric (func): The function to log the message status to - log as success, timeout, or error
-        """
-        logger.info(f"Function {func_name} executed, passing to {logging_metric}")
-        OPEN_TELEMETRY_EXPORTER.log_execution_status(func_name, logging_metric)
+    # @staticmethod
+    # def log_execution_time(func_name: str, execution_time: float):
+    #     """
+    #     Logs the execution time of a function to OpenTelemetry.
+    #
+    #     Parameters:
+    #     - func_name (str): The name of the function that was executed.
+    #     - execution_time (float): The time taken to execute the function.
+    #     """
+    #     logger.debug(f"Function {func_name} executed in {execution_time:.2f} seconds.")
+    #     OPEN_TELEMETRY_EXPORTER.log_execution_time(func_name, execution_time)
+    #
+    # @staticmethod
+    # def log_execution_status(func_name: str, logging_metric: str):
+    #     """
+    #     Logs the execution of a function to CloudWatch.
+    #
+    #     Parameters:
+    #     - func_name (str): The name of the function that was executed.
+    #     - logging_metric (func): The function to log the message status to - log as success, timeout, or error
+    #     """
+    #     logger.info(f"Function {func_name} executed, passing to {logging_metric}")
+    #     OPEN_TELEMETRY_EXPORTER.log_execution_status(func_name, logging_metric)
 
     @staticmethod
     def log_and_handle_error(error):

--- a/test/lib/queue/test_queue.py
+++ b/test/lib/queue/test_queue.py
@@ -68,17 +68,17 @@ class TestQueueWorker(unittest.TestCase):
         self.assertFalse(success)
         mock_log_error.assert_called_once_with("Model respond timeout exceeded.")
 
-    @patch('lib.queue.worker.QueueWorker.log_and_handle_error')
-    @patch('lib.queue.worker.time.time', side_effect=[0, 0.5])
-    @patch('lib.queue.worker.QueueWorker.log_execution_time')
-    @patch('lib.queue.worker.QueueWorker.log_execution_status')
-    def test_execute_with_timeout_success(self, mock_log_execution_status, mock_log_execution_time, mock_time, mock_log_error):
-        responses, success = self.queue.execute_with_timeout(TestModelNoTimeout(), [], timeout_seconds=1)
-        self.assertEqual(responses in [[], ["response"]], True)
-        self.assertTrue(success)
-        mock_log_error.assert_not_called()
-        mock_log_execution_time.assert_called_once_with('timeout.TestModelNoTimeout', 0.5)
-        mock_log_execution_status.assert_called_once_with('timeout.TestModelNoTimeout', 'successful_message_response')
+    # @patch('lib.queue.worker.QueueWorker.log_and_handle_error')
+    # @patch('lib.queue.worker.time.time', side_effect=[0, 0.5])
+    # @patch('lib.queue.worker.QueueWorker.log_execution_time')
+    # @patch('lib.queue.worker.QueueWorker.log_execution_status')
+    # def test_execute_with_timeout_success(self, mock_log_execution_status, mock_log_execution_time, mock_time, mock_log_error):
+    #     responses, success = self.queue.execute_with_timeout(TestModelNoTimeout(), [], timeout_seconds=1)
+    #     self.assertEqual(responses in [[], ["response"]], True)
+    #     self.assertTrue(success)
+    #     mock_log_error.assert_not_called()
+    #     mock_log_execution_time.assert_called_once_with('timeout.TestModelNoTimeout', 0.5)
+    #     mock_log_execution_status.assert_called_once_with('timeout.TestModelNoTimeout', 'successful_message_response')
 
     def test_process(self):
         self.queue.receive_messages = MagicMock(return_value=[(FakeSQSMessage(receipt_handle="blah", body=json.dumps({


### PR DESCRIPTION
Looks like we're hemorrhaging errors and at least one likely culprit is continuous errors from OpenTelemetry mentioning timeout errors. Turn off OpenTelemetry for the moment to try to debug where the hangup is. 