### PR TITLE
CV2-4725 decrease timeout on telemetry pings from 60s to 10s

### DIFF
--- a/lib/telemetry.py
+++ b/lib/telemetry.py
@@ -31,7 +31,7 @@ class OpenTelemetryExporter:
             # write metrics to console instead of sending them
             reader = PeriodicExportingMetricReader(
                 ConsoleMetricExporter(),
-                export_interval_millis=int(os.getenv("METRICS_REPORTING_INTERVAL", "60000")),
+                export_interval_millis=int(os.getenv("METRICS_REPORTING_INTERVAL", "10000")),
             )
             meter_provider = MeterProvider(resource=resource, metric_readers=[reader])
         else:
@@ -50,7 +50,7 @@ class OpenTelemetryExporter:
                             "X-Honeycomb-Dataset": honeycomb_dataset,
                         },
                     ),
-                    export_interval_millis=int(os.getenv("METRICS_REPORTING_INTERVAL", "60000")),
+                    export_interval_millis=int(os.getenv("METRICS_REPORTING_INTERVAL", "10000")),
                 )
                 meter_provider = MeterProvider(resource=resource, metric_readers=[reader])
         metrics.set_meter_provider(meter_provider)

--- a/test/lib/test_telemetry.py
+++ b/test/lib/test_telemetry.py
@@ -14,7 +14,7 @@ from lib.telemetry import OpenTelemetryExporter
 def set_env_vars():
     os.environ['HONEYCOMB_API_KEY'] = 'test_api_key'
     os.environ['HONEYCOMB_DATASET'] = 'test_dataset'
-    os.environ['METRICS_REPORTING_INTERVAL'] = '60000'
+    os.environ['METRICS_REPORTING_INTERVAL'] = '10000'
     os.environ['HONEYCOMB_API_ENDPOINT'] = 'https://api.honeycomb.io'
     os.environ['DEPLOY_ENV'] = 'test_env'
     yield


### PR DESCRIPTION
## Description
As per discussion with @skyemeedan we're trying to isolate why Presto hemorrhages opentelemetry timeouts but timpani doesn't - one diff is this timeout count so removing that as a variable.

Reference: CV2-4725

## How has this been tested?
Tested the parsing of a non value and works fine

## Are there any external dependencies?
none

## Have you considered secure coding practices when writing this code?
none
