### PR TITLE
CV2-4719 initial idea saround caching layer in presto

### DIFF
--- a/.env_file.example
+++ b/.env_file.example
@@ -12,3 +12,5 @@ OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
 OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=XXX"
 HONEYCOMB_API_ENDPOINT="https://api.honeycomb.io"
+REDIS_URL="redis://redis:6379/0"
+CACHE_DEFAULT_TTL=86400

--- a/.env_file.test
+++ b/.env_file.test
@@ -12,3 +12,5 @@ OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
 OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=XXX"
 HONEYCOMB_API_ENDPOINT="https://api.honeycomb.io"
+REDIS_URL="redis://redis:6379/0"
+CACHE_DEFAULT_TTL=86400

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     depends_on:
       elasticmq:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     links:
       - elasticmq
     volumes:
@@ -41,6 +43,16 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
+  redis:
+    image: redis:latest
+    hostname: presto-redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   image:
     build: .
     platform: linux/amd64
@@ -53,6 +65,8 @@ services:
       MODEL_NAME: image.Model
     depends_on:
       elasticmq:
+        condition: service_healthy
+      redis:
         condition: service_healthy
   audio:
     build: .
@@ -67,6 +81,8 @@ services:
     depends_on:
       elasticmq:
         condition: service_healthy
+      redis:
+        condition: service_healthy
   yake:
     build: .
     platform: linux/amd64
@@ -79,4 +95,6 @@ services:
       MODEL_NAME: yake_keywords.Model
     depends_on:
       elasticmq:
+        condition: service_healthy
+      redis:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
         - OTEL_EXPORTER_OTLP_HEADERS=${OTEL_EXPORTER_OTLP_HEADERS}
         - HONEYCOMB_API_KEY=${HONEYCOMB_API_KEY}
         - HONEYCOMB_API_ENDPOINT=${HONEYCOMB_API_ENDPOINT}
+        - REDIS_URL=${REDIS_URL}
+        - CACHE_DEFAULT_TTL=${CACHE_DEFAULT_TTL}
     env_file:
       - ./.env_file
     depends_on:

--- a/lib/cache.py
+++ b/lib/cache.py
@@ -29,12 +29,13 @@ class Cache:
         Returns:
             Optional[Any]: The cached result, or None if the key does not exist.
         """
-        client = Cache.get_client()
-        cached_result = client.get(content_hash)
-        if cached_result is not None:
-            if reset_ttl:
-                client.expire(content_hash, ttl)
-            return json.loads(cached_result)
+        if content_hash:
+            client = Cache.get_client()
+            cached_result = client.get(content_hash)
+            if cached_result is not None:
+                if reset_ttl:
+                    client.expire(content_hash, ttl)
+                return json.loads(cached_result)
         return None
 
     @staticmethod

--- a/lib/cache.py
+++ b/lib/cache.py
@@ -1,0 +1,51 @@
+import redis
+import json
+from typing import Any, Optional
+from lib.helpers import get_environment_setting
+
+REDIS_URL = get_environment_setting("REDIS_URL")
+DEFAULT_TTL = int(get_environment_setting("CACHE_DEFAULT_TTL") or 24*60*60)
+class Cache:
+    @staticmethod
+    def get_client() -> redis.Redis:
+        """
+        Get a Redis client instance using the provided REDIS_URL.
+
+        Returns:
+            redis.Redis: Redis client instance.
+        """
+        return redis.Redis.from_url(REDIS_URL)
+
+    @staticmethod
+    def get_cached_result(content_hash: str, reset_ttl: bool = True, ttl: int = DEFAULT_TTL) -> Optional[Any]:
+        """
+        Retrieve the cached result for the given content hash. By default, reset the TTL to 24 hours.
+
+        Args:
+            content_hash (str): The key for the cached content.
+            reset_ttl (bool): Whether to reset the TTL upon access. Default is True.
+            ttl (int): Time-to-live for the cache in seconds. Default is 86400 seconds (24 hours).
+
+        Returns:
+            Optional[Any]: The cached result, or None if the key does not exist.
+        """
+        client = Cache.get_client()
+        cached_result = client.get(content_hash)
+        if cached_result is not None:
+            if reset_ttl:
+                client.expire(content_hash, ttl)
+            return json.loads(cached_result)
+        return None
+
+    @staticmethod
+    def set_cached_result(content_hash: str, result: Any, ttl: int = DEFAULT_TTL) -> None:
+        """
+        Store the result in the cache with the given content hash and TTL.
+
+        Args:
+            content_hash (str): The key for the cached content.
+            result (Any): The result to cache.
+            ttl (int): Time-to-live for the cache in seconds. Default is 86400 seconds (24 hours).
+        """
+        client = Cache.get_client()
+        client.setex(content_hash, ttl, json.dumps(result))

--- a/lib/cache.py
+++ b/lib/cache.py
@@ -5,6 +5,7 @@ from lib.helpers import get_environment_setting
 
 REDIS_URL = get_environment_setting("REDIS_URL")
 DEFAULT_TTL = int(get_environment_setting("CACHE_DEFAULT_TTL") or 24*60*60)
+CACHE_PREFIX = "presto_media_cache:"
 class Cache:
     @staticmethod
     def get_client() -> redis.Redis:
@@ -31,10 +32,10 @@ class Cache:
         """
         if content_hash:
             client = Cache.get_client()
-            cached_result = client.get(content_hash)
+            cached_result = client.get(CACHE_PREFIX+content_hash)
             if cached_result is not None:
                 if reset_ttl:
-                    client.expire(content_hash, ttl)
+                    client.expire(CACHE_PREFIX+content_hash, ttl)
                 return json.loads(cached_result)
         return None
 
@@ -50,4 +51,4 @@ class Cache:
         """
         if content_hash:
             client = Cache.get_client()
-            client.setex(content_hash, ttl, json.dumps(result))
+            client.setex(CACHE_PREFIX+content_hash, ttl, json.dumps(result))

--- a/lib/cache.py
+++ b/lib/cache.py
@@ -48,5 +48,6 @@ class Cache:
             result (Any): The result to cache.
             ttl (int): Time-to-live for the cache in seconds. Default is 86400 seconds (24 hours).
         """
-        client = Cache.get_client()
-        client.setex(content_hash, ttl, json.dumps(result))
+        if content_hash:
+            client = Cache.get_client()
+            client.setex(content_hash, ttl, json.dumps(result))

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -8,6 +8,7 @@ import urllib.request
 from lib.helpers import get_class
 from lib import schemas
 from lib.cache import Cache
+
 class Model(ABC):
     BATCH_SIZE = 1
     def __init__(self):

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -47,7 +47,7 @@ class Model(ABC):
         result = Cache.get_cached_result(message.body.content_hash)
         if not result:
             result = self.process(message)
-            Cache.set_cached_result(message.body.content_hash, message.body.result)
+            Cache.set_cached_result(message.body.content_hash, result)
         return result
 
     def respond(self, messages: Union[List[schemas.Message], schemas.Message]) -> List[schemas.Message]:

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -46,7 +46,12 @@ class Model(ABC):
         if not isinstance(messages, list):
             messages = [messages]
         for message in messages:
-            message.body.result = self.process(message)
+            existing = Cache.get_cached_result(message.body.content_hash)
+            if existing:
+                message.body.result = existing
+            else:
+                message.body.result = self.process(message)
+                Cache.set_cached_result(message.body.content_hash, message.body.result)
         return messages
     
     @classmethod

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -7,6 +7,7 @@ import urllib.request
 
 from lib.helpers import get_class
 from lib import schemas
+from lib.cache import Cache
 class Model(ABC):
     BATCH_SIZE = 1
     def __init__(self):

--- a/lib/schemas.py
+++ b/lib/schemas.py
@@ -13,6 +13,7 @@ class YakeKeywordsResponse(BaseModel):
 
 class GenericItem(BaseModel):
     id: Union[str, int, float]
+    content_hash: Optional[str] = None
     callback_url: Optional[str] = None
     url: Optional[str] = None
     text: Optional[str] = None

--- a/lib/telemetry.py
+++ b/lib/telemetry.py
@@ -75,6 +75,16 @@ class OpenTelemetryExporter:
             unit="s",
             description="Errored Message Response"
         )
+        self.cache_hit_response = self.meter.create_counter(
+            name="cache_hit_response",
+            unit="s",
+            description="Returned cached response"
+        )
+        self.cache_miss_response = self.meter.create_counter(
+            name="cache_miss_response",
+            unit="s",
+            description="Returned non-cached response"
+        )
 
     def log_execution_time(self, func_name: str, execution_time: float):
         env_name = os.getenv("DEPLOY_ENV", "development")

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ yake==0.4.8
 opentelemetry-api==1.24.0
 opentelemetry-exporter-otlp-proto-http==1.24.0
 opentelemetry-sdk==1.24.0
+redis==5.0.6

--- a/test/lib/model/test_video.py
+++ b/test/lib/model/test_video.py
@@ -48,7 +48,11 @@ class TestVideoModel(unittest.TestCase):
         result = self.video_model.tmk_program_name()
         self.assertEqual(result, "PrestoVideoEncoder")
 
-    def test_respond_with_single_video(self):
+    @patch('lib.cache.Cache.get_cached_result')
+    @patch('lib.cache.Cache.set_cached_result')
+    def test_respond_with_single_video(self, mock_cache_set, mock_cache_get):
+        mock_cache_get.return_value = None
+        mock_cache_set.return_value = True
         video = schemas.parse_message({"body": {"id": "123", "callback_url": "http://blah.com?callback_id=123", "url": "http://example.com/video.mp4"}, "model_name": "video__Model"})
         mock_process = MagicMock()
         self.video_model.process = mock_process
@@ -56,10 +60,11 @@ class TestVideoModel(unittest.TestCase):
         mock_process.assert_called_once_with(video)
         self.assertEqual(result, [video])
 
-    @patch('lib.cache.Cache')
-    def test_respond_with_multiple_videos(self, mock_cache):
-        mock_cache.get_cached_result.return_value = None
-        mock_cache.set_cached_result.return_value = True
+    @patch('lib.cache.Cache.get_cached_result')
+    @patch('lib.cache.Cache.set_cached_result')
+    def test_respond_with_multiple_videos(self, mock_cache_set, mock_cache_get):
+        mock_cache_get.return_value = None
+        mock_cache_set.return_value = True
         videos = [schemas.parse_message({"body": {"id": "123", "callback_url": "http://blah.com?callback_id=123", "url": "http://example.com/video.mp4"}, "model_name": "video__Model"}), schemas.parse_message({"body": {"id": "123", "callback_url": "http://blah.com?callback_id=123", "url": "http://example.com/video2.mp4"}, "model_name": "video__Model"})]
         mock_process = MagicMock()
         self.video_model.process = mock_process

--- a/test/lib/model/test_video.py
+++ b/test/lib/model/test_video.py
@@ -56,7 +56,10 @@ class TestVideoModel(unittest.TestCase):
         mock_process.assert_called_once_with(video)
         self.assertEqual(result, [video])
 
-    def test_respond_with_multiple_videos(self):
+    @patch('lib.cache.Cache')
+    def test_respond_with_multiple_videos(self, mock_cache):
+        mock_cache.get_cached_result.return_value = None
+        mock_cache.set_cached_result.return_value = True
         videos = [schemas.parse_message({"body": {"id": "123", "callback_url": "http://blah.com?callback_id=123", "url": "http://example.com/video.mp4"}, "model_name": "video__Model"}), schemas.parse_message({"body": {"id": "123", "callback_url": "http://blah.com?callback_id=123", "url": "http://example.com/video2.mp4"}, "model_name": "video__Model"})]
         mock_process = MagicMock()
         self.video_model.process = mock_process

--- a/test/lib/queue/test_queue.py
+++ b/test/lib/queue/test_queue.py
@@ -147,19 +147,19 @@ class TestQueueWorker(unittest.TestCase):
         mock_logger.assert_called_with(f"Deleting message: {mock_messages[-1]}")
 
     def test_push_message(self):
-        message_to_push = schemas.parse_message({"body": {"id": 1, "callback_url": "http://example.com", "text": "This is a test"}, "model_name": "mean_tokens__Model"})
+        message_to_push = schemas.parse_message({"body": {"id": 1, "content_hash": None, "callback_url": "http://example.com", "text": "This is a test"}, "model_name": "mean_tokens__Model"})
         # Call push_message
         returned_message = self.queue.push_message(self.queue_name_output, message_to_push)
         # Check if the message was correctly serialized and sent
-        self.mock_output_queue.send_message.assert_called_once_with(MessageBody='{"body": {"id": 1, "callback_url": "http://example.com", "url": null, "text": "This is a test", "raw": {}, "parameters": {}, "result": {"hash_value": null}}, "model_name": "mean_tokens__Model", "retry_count": 0}')
+        self.mock_output_queue.send_message.assert_called_once_with(MessageBody='{"body": {"id": 1, "content_hash": null, "callback_url": "http://example.com", "url": null, "text": "This is a test", "raw": {}, "parameters": {}, "result": {"hash_value": null}}, "model_name": "mean_tokens__Model", "retry_count": 0}')
         self.assertEqual(returned_message, message_to_push)
 
     def test_push_to_dead_letter_queue(self):
-        message_to_push = schemas.parse_message({"body": {"id": 1, "callback_url": "http://example.com", "text": "This is a test"}, "model_name": "mean_tokens__Model"})
+        message_to_push = schemas.parse_message({"body": {"id": 1, "content_hash": None, "callback_url": "http://example.com", "text": "This is a test"}, "model_name": "mean_tokens__Model"})
         # Call push_to_dead_letter_queue
         self.queue.push_to_dead_letter_queue(message_to_push)
         # Check if the message was correctly serialized and sent to the DLQ
-        self.mock_dlq_queue.send_message.assert_called_once_with(MessageBody='{"body": {"id": 1, "callback_url": "http://example.com", "url": null, "text": "This is a test", "raw": {}, "parameters": {}, "result": {"hash_value": null}}, "model_name": "mean_tokens__Model", "retry_count": 0}')
+        self.mock_dlq_queue.send_message.assert_called_once_with(MessageBody='{"body": {"id": 1,"content_hash": null,  "callback_url": "http://example.com", "url": null, "text": "This is a test", "raw": {}, "parameters": {}, "result": {"hash_value": null}}, "model_name": "mean_tokens__Model", "retry_count": 0}')
 
     def test_increment_message_error_counts_exceed_max_retries(self):
         message_body = {

--- a/test/lib/queue/test_queue.py
+++ b/test/lib/queue/test_queue.py
@@ -159,7 +159,7 @@ class TestQueueWorker(unittest.TestCase):
         # Call push_to_dead_letter_queue
         self.queue.push_to_dead_letter_queue(message_to_push)
         # Check if the message was correctly serialized and sent to the DLQ
-        self.mock_dlq_queue.send_message.assert_called_once_with(MessageBody='{"body": {"id": 1,"content_hash": null,  "callback_url": "http://example.com", "url": null, "text": "This is a test", "raw": {}, "parameters": {}, "result": {"hash_value": null}}, "model_name": "mean_tokens__Model", "retry_count": 0}')
+        self.mock_dlq_queue.send_message.assert_called_once_with(MessageBody='{"body": {"id": 1, "content_hash": null, "callback_url": "http://example.com", "url": null, "text": "This is a test", "raw": {}, "parameters": {}, "result": {"hash_value": null}}, "model_name": "mean_tokens__Model", "retry_count": 0}')
 
     def test_increment_message_error_counts_exceed_max_retries(self):
         message_body = {

--- a/test/lib/test_cache.py
+++ b/test/lib/test_cache.py
@@ -16,7 +16,7 @@ def test_set_cached_result(mock_redis_client):
 
     Cache.set_cached_result(content_hash, result, ttl)
 
-    mock_instance.setex.assert_called_once_with(content_hash, ttl, '{"data": "example"}')
+    mock_instance.setex.assert_called_once_with('presto_media_cache:'+content_hash, ttl, '{"data": "example"}')
 
 def test_get_cached_result_exists(mock_redis_client):
     mock_instance = mock_redis_client.from_url.return_value
@@ -28,7 +28,7 @@ def test_get_cached_result_exists(mock_redis_client):
     result = Cache.get_cached_result(content_hash, reset_ttl=True, ttl=ttl)
 
     assert result == {"data": "example"}
-    mock_instance.expire.assert_called_once_with(content_hash, ttl)
+    mock_instance.expire.assert_called_once_with('presto_media_cache:'+content_hash, ttl)
 
 def test_get_cached_result_not_exists(mock_redis_client):
     mock_instance = mock_redis_client.from_url.return_value

--- a/test/lib/test_cache.py
+++ b/test/lib/test_cache.py
@@ -1,0 +1,52 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from lib.cache import Cache
+
+# Mock the Redis client and its methods
+@pytest.fixture
+def mock_redis_client():
+    with patch('lib.cache.redis.Redis') as mock_redis:
+        yield mock_redis
+
+def test_set_cached_result(mock_redis_client):
+    mock_instance = mock_redis_client.from_url.return_value
+    content_hash = "test_hash"
+    result = {"data": "example"}
+    ttl = 3600
+
+    Cache.set_cached_result(content_hash, result, ttl)
+
+    mock_instance.setex.assert_called_once_with(content_hash, ttl, '{"data": "example"}')
+
+def test_get_cached_result_exists(mock_redis_client):
+    mock_instance = mock_redis_client.from_url.return_value
+    content_hash = "test_hash"
+    ttl = 3600
+    cached_data = '{"data": "example"}'
+    mock_instance.get.return_value = cached_data
+
+    result = Cache.get_cached_result(content_hash, reset_ttl=True, ttl=ttl)
+
+    assert result == {"data": "example"}
+    mock_instance.expire.assert_called_once_with(content_hash, ttl)
+
+def test_get_cached_result_not_exists(mock_redis_client):
+    mock_instance = mock_redis_client.from_url.return_value
+    content_hash = "test_hash"
+    mock_instance.get.return_value = None
+
+    result = Cache.get_cached_result(content_hash)
+
+    assert result is None
+    mock_instance.expire.assert_not_called()
+
+def test_get_cached_result_no_ttl_reset(mock_redis_client):
+    mock_instance = mock_redis_client.from_url.return_value
+    content_hash = "test_hash"
+    cached_data = '{"data": "example"}'
+    mock_instance.get.return_value = cached_data
+
+    result = Cache.get_cached_result(content_hash, reset_ttl=False)
+
+    assert result == {"data": "example"}
+    mock_instance.expire.assert_not_called()


### PR DESCRIPTION
## Description
Adds a redis caching layer to presto to optionally bypass the fingerprinting routine for already-fingerprinted items. Also adds ability to flexibly define ttl and optionally bypass that.

Reference: CV2-4719

## How has this been tested?
Not yet tested locally - will do integration testing once unit tests passing on all three services

## Are there any external dependencies?
Adds redis - will need to make sure we can access it with @sonoransun 

## Have you considered secure coding practices when writing this code?
Nothing particularly interesting here
