### PR TITLE
CV2-4978: Local callback server for receiving presto callback responses

### DIFF
--- a/extra/callback_server.py
+++ b/extra/callback_server.py
@@ -1,0 +1,30 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import sys
+
+
+class RequestHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        content_length = int(self.headers['Content-Length'])
+        post_data = self.rfile.read(content_length)
+
+        print("Received POST request:")
+        print(post_data.decode('utf-8'))
+
+        self.send_response(200)
+        self.send_header('Content-type', 'text/plain')
+        self.end_headers()
+        self.wfile.write(b"{\"message\": \"Message Received\"}")
+
+
+def run_server(port=9888):
+    server_address = ('', port)
+    httpd = HTTPServer(server_address, RequestHandler)
+    print(f"Server running on port {port}")
+    httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    port = 9888
+    if len(sys.argv) > 1:
+        port = int(sys.argv[1])
+    run_server(port)

--- a/extra/callback_server.py
+++ b/extra/callback_server.py
@@ -1,7 +1,7 @@
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import sys, os
 
-DEFAULT_PORT = os.getenv('LOCAL_CALLBACK_PORT', 9888)
+DEFAULT_PORT = int(os.getenv('LOCAL_CALLBACK_PORT', 9888))
 
 
 class RequestHandler(BaseHTTPRequestHandler):

--- a/extra/callback_server.py
+++ b/extra/callback_server.py
@@ -1,5 +1,7 @@
 from http.server import HTTPServer, BaseHTTPRequestHandler
-import sys
+import sys, os
+
+DEFAULT_PORT = os.getenv('LOCAL_CALLBACK_PORT', 9888)
 
 
 class RequestHandler(BaseHTTPRequestHandler):
@@ -16,7 +18,7 @@ class RequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(b"{\"message\": \"Message Received\"}")
 
 
-def run_server(port=9888):
+def run_server(port=DEFAULT_PORT):
     server_address = ('', port)
     httpd = HTTPServer(server_address, RequestHandler)
     print(f"Server running on port {port}")
@@ -24,7 +26,7 @@ def run_server(port=9888):
 
 
 if __name__ == '__main__':
-    port = 9888
+    port = DEFAULT_PORT
     if len(sys.argv) > 1:
         port = int(sys.argv[1])
     run_server(port)


### PR DESCRIPTION
## Description
Simple python code for a callback server that spins up on an input port (9888 by default) and receives and prints post requests, which can be used as the callback server for testing/debugging presto locally.

Reference: TICKET-ID (to provide additional context)
[CV2-4978](https://meedan.atlassian.net/browse/CV2-4978)

## How has this been tested?
Has it been tested locally? Are there automated tests?
This has been tested while developing classycat in presto and works fine

## Are there any external dependencies?
No

## Have you considered secure coding practices when writing this code?
Only use this locally, not to be used in production or security sensitive use cases


[CV2-4978]: https://meedan.atlassian.net/browse/CV2-4978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ