### PR TITLE
double check returned categories to make sure they are in-schema + tests

### DIFF
--- a/lib/model/classycat_classify.py
+++ b/lib/model/classycat_classify.py
@@ -130,6 +130,11 @@ class Model(Model):
         # and items with no labels can be retried later by the user, indicated by an empty list for labels
         permitted_labels = [topic['topic'] for topic in schema['topics']] + ['Other', 'Unsure']
         for result in final_results:
+
+            # log the items that had at least one out-of-schema label
+            if not all([label in permitted_labels for label in result['labels']]):
+                logger.error(f"Item {result['id']} had out-of-schema labels: {result['labels']}, permitted labels: {permitted_labels}")
+
             result['labels'] = [label for label in result['labels'] if label in permitted_labels]
 
         if not all([len(result['labels']) == 0 for result in final_results]):

--- a/lib/model/classycat_classify.py
+++ b/lib/model/classycat_classify.py
@@ -126,8 +126,11 @@ class Model(Model):
                          for i in range(len(items))]
 
         # filtering out the results that have out-of-schema labels
+        # our of schema labels will not be included in the final results,
+        # and items with no labels can be retried later by the user, indicated by an empty list for labels
         permitted_labels = [topic['topic'] for topic in schema['topics']] + ['Other', 'Unsure']
-        final_results = [result for result in final_results if all(label in permitted_labels for label in result['labels'])]
+        for result in final_results:
+            result['labels'] = [label for label in result['labels'] if label in permitted_labels]
 
         if len(final_results) == 0:
             logger.info(f"The returned classifications did not produce labels from the schema: {items}")

--- a/lib/model/classycat_classify.py
+++ b/lib/model/classycat_classify.py
@@ -132,12 +132,9 @@ class Model(Model):
         for result in final_results:
             result['labels'] = [label for label in result['labels'] if label in permitted_labels]
 
-        if len(final_results) == 0:
-            logger.info(f"The returned classifications did not produce labels from the schema: {items}")
-            raise Exception(f"No items were classified successfully")
-
-        results_file_id = str(uuid.uuid4())
-        upload_file_to_s3(self.output_bucket, f"{schema_id}/{results_file_id}.json", json.dumps(final_results))
+        if not all([len(result['labels']) == 0 for result in final_results]):
+            results_file_id = str(uuid.uuid4())
+            upload_file_to_s3(self.output_bucket, f"{schema_id}/{results_file_id}.json", json.dumps(final_results))
 
         return final_results
 

--- a/test/lib/model/test_classycat.py
+++ b/test/lib/model/test_classycat.py
@@ -704,5 +704,290 @@ class TestClassyCat(TestCase):
 
         self.assertEqual(result.responseMessage, "Error classifying items: Not all items were classified successfully: input length 1, output length 2")
 
+    @patch('lib.model.classycat_classify.OpenRouterClient.classify')
+    @patch('lib.model.classycat_classify.load_file_from_s3')
+    @patch('lib.model.classycat_classify.upload_file_to_s3')
+    @patch('lib.model.classycat_classify.file_exists_in_s3')
+    def test_classify_pass_some_out_of_schema_labels(self, file_exists_in_s3_mock, upload_file_to_s3_mock,
+                                                     load_file_from_s3_mock, openrouter_classify_mock):
+        file_exists_in_s3_mock.return_value = True
+        upload_file_to_s3_mock.return_value = None
+        load_file_from_s3_mock.return_value = json.dumps(
+            {
+                "schema_id": "123456",
+                "schema_name": "2024 Indian Election Test",
+                "prompt": "fake prompt hehe",
+                "topics": [
+                    {
+                        "topic": "Politics",
+                        "description": "This topic includes political claims, attacks on leaders and parties, and general political commentary."
+                    },
+                    {
+                        "topic": "Democracy & Election Integrity",
+                        "description": "This topic covers the integrity of the election process, including voter fraud, election fraud, the security of voting machines, and election interference, and electoral bonds."
+                    },
+                    {
+                        "topic": "Economy & Growth",
+                        "description": "This topic covers claims around economic growth, economic policies, GDP , employment, taxation, issues among farmer and manufacturing industry, and economic inequality."
+                    },
+                    {
+                        "topic": "Communalism",
+                        "description": "This topic covers attack on religious minorities, statements on religious freedom and polarization."
+                    },
+                    {
+                        "topic": "Education",
+                        "description": "This topic covers education policy of governments, educational institutions created, and quality of education in India."
+                    },
+                    {
+                        "topic": "Freedom of Expression",
+                        "description": "This topic covers claims regarding freedom of expression and  independence of media, and attacks on press freedom and journalists."
+                    },
+                    {
+                        "topic": "Foreign Policy",
+                        "description": "This topic covers India's relationship with neighbours and other countries, claims on effectiveness of foreign policy, international image and diplomacy."
+                    },
+                    {
+                        "topic": "Safety of Women",
+                        "description": "This topic covers the issue of safety of women and steps taken to prevent crimes against women. "
+                    },
+                    {
+                        "topic": "Social Issues",
+                        "description": "This topic covers topics on the citizenship ammendmend act and caste politics."
+                    },
+                    {
+                        "topic": "Health & Pharma",
+                        "description": "This topic covers health policies, claims on ayurveda, maternal and infant mortality, and the pharmaceutical industry."
+                    },
+                    {
+                        "topic": "Terrorism & National Security",
+                        "description": "This topics covers claims on UAPA, National security, Pakistan, and terrorism."
+                    },
+                    {
+                        "topic": "Corruption",
+                        "description": "This topic covers claims on corruptions and scams."
+                    },
+                    {
+                        "topic": "History",
+                        "description": "This topic covers claim on history of India and mythology."
+                    },
+                    {
+                        "topic": "Science & Technology",
+                        "description": "This topic covers claims on climate change, environment and science."
+                    },
+                    {
+                        "topic": "Banking & Finance",
+                        "description": "This topic covers claims around finance and banking."
+                    }
+                ],
+                "examples": [
+                    {
+                        "text": "Congress Manifesto is horrible. Never seen such a dangerous manifesto in my life. It's like vision 2047 document of PFI\n\nCheck these points of manifesto\n\n1. Will bring back triple talak (Muslim personal law)\n2. Reservation to Muslim in govt n private jobs (Implement Sachchar committee report)\n3. Support Love Jihad (right to love)\n4. Support Burqa in school (right to dress)\n5. End majoritarianism (Hinduism)\n6. Ban bulldozer action\n7. Support Gaza (Hamas)\n8. Legalise Same Sex Marriage, gender fluidity, trans movement\n9. Increase Muslim judges in judiciary\n10. Communal violence bill (will stop mob lynching)\n11. Legalise beef (right to eat everything)\n12. Separate loan intrest for Muslims\n13. Allow treason (No sedition)\n\nAll those Hindu who are thinking to vote Indi Alliance, NOTA or independent. Read this and think.\n",
+                        "labels": [
+                            "Politics",
+                            "Communalism"
+                        ]
+                    },
+                    {
+                        "text": "RSS ने अपने नागपुर मुख्यालय से 2024 लोकसभा चुनाव में कॉंग्रेस गठबंधन को समर्थन करने की घोषणा की कमाल की बात ये है कि इतनी महत्वपूर्ण खबर किसी भी news channel, और अखबार ने नहीं छापी RSS ने माना कि आज नरेंद्र मोदी भाजपा सरकार में देश का संविधान और लोकतंत्र खतरे में है इसलिए भाजपा को 2024 में रोकना अति आवश्यक है अगर देश की जनता धर्म के नशे में डूबी रही तो आने वाली नस्लें तुम्हें कभी माफ़ नहीं करेगी देश आज संकट में है और जो व्यक्ति इस समय कॉंग्रेस का साथ नहीं देगा वो भविष्य में खुद को कभी माफ़ नहीं कर पाएगा इस खबर को शेयर करके देश के एक जिम्मेदार नागरिक होने का फर्ज पूरा कीजिए",
+                        "labels": [
+                            "Politics",
+                            "Democracy & Election Integrity"
+                        ]
+                    },
+                    {
+                        "text": "बेहद गंभीर मामला है। खबरों के मुताबिक, दवा बनाने वाली बहुत सी कंपनियां जिनकी दवाएं टेस्ट में फेल हुईं, इन कंपनियों ने इलेक्टोरल बॉन्ड से चंदा दिया। जैसे \uD83D\uDC47 1. गुजरात की कंपनी 'टोरेंट फार्मास्यूटिकल' की बनाई 3 दवाएं ड्रग टेस्ट में फेल हुईं। इस कंपनी ने BJP को 61 करोड़ का चंदा दिया। 2. सिप्ला लिमिटेड कंपनी की बनाई दवाओं के 7 बार ड्रग टेस्ट फ़ेल हुए। इस कंपनी ने BJP को 37 करोड़ का चंदा दिया। 3. सन फ़ार्मा कंपनी की बनाई गई दवाओं के 6 बार ड्रग टेस्ट फ़ेल हुए। सन फार्मा ने BJP को 31.5 करोड़ रुपए का चंदा दिया। 4. गुजरात की कंपनी इंटास फ़ार्मास्युटिकल्स की बनाई गई दवा का भी ड्रग टेस्ट फ़ेल हुआ। इंटास फ़ार्मा ने 20 करोड़ के इलेक्टोरल बॉन्ड ख़रीदे और सारा चंदा BJP को दिया। 5. ग्लेनमार्क फ़ार्मा कंपनी की दवाओं के 6 ड्रग टेस्ट फ़ेल हुए। ग्लेनमार्क फ़ार्मा 9.75 करोड़ रुपए के बॉन्ड ख़रीदे और सारा चंदा BJP को दिया।",
+                        "labels": [
+                            "Corruption",
+                            "Health & Pharma",
+                            "Politics"
+                        ]
+                    },
+                    {
+                        "text": "യുഎഇ അബുദാബിയിലെയും ദുബായിലെയും എല്ലാ അറബ് മന്ത്രിമാരും അറബ് ഷേക്'മാരും റമദാൻ മാസത്തിൽ ഇന്ന് അബുദാബി ഹിന്ദു ക്ഷേത്രത്തിലെത്തി പ്രസാദത്തോടെ ക്ഷേത്രത്തിൽ റമദാൻ വ്രതം പൂർത്തിയാക്കി. (ഇതൊരു വലിയ അത്ഭുതമാണ്.) ഈ വീഡിയോ കാണുക.\uD83D\uDEA9\uD83D\uDEA9\uD83D\uDEA9\n\n",
+                        "labels": [
+                            "Foreign Policy",
+                            "Politics",
+                            "Communalism"
+                        ]
+                    }
+                ],
+                "languages": [
+                    "English",
+                    "Hindi",
+                    "Telugu",
+                    "Malayalam"
+                ]
+            }
+        )
+        openrouter_classify_mock.return_value = "<OUTPUT>\n<CATEGORIES_0>Politics;Communalism</CATEGORIES_0>\n<CATEGORIES_1>Politico;Communism</CATEGORIES_1>\n</OUTPUT>"
+        classify_input = {
+            "model_name": "classycat__Model",
+            "body": {
+                "id": 1200,
+                "parameters": {
+                    "event_type": "classify",
+                    "schema_id": "4a026b82-4a16-440d-aed7-bec07af12205",
+                    "items": [
+                        {
+                            "id": "11",
+                            "text": "modi and bjp want to rule india by dividing people against each other"
+                        },
+                        {
+                            "id": "12",
+                            "text": "modi and bjp are amazing politicians"
+                        }
+                    ]
+                },
+                "callback_url": "http://example.com?callback"
+            }
+        }
+        classify_message = schemas.parse_message(classify_input)
+        result = self.classycat_model.process(classify_message)
+
+        self.assertEqual("success", result.responseMessage)
+        self.assertEqual(1, len(result.classification_results))
+
+    @patch('lib.model.classycat_classify.OpenRouterClient.classify')
+    @patch('lib.model.classycat_classify.load_file_from_s3')
+    @patch('lib.model.classycat_classify.upload_file_to_s3')
+    @patch('lib.model.classycat_classify.file_exists_in_s3')
+    def test_classify_fail_all_out_of_schema_labels(self, file_exists_in_s3_mock, upload_file_to_s3_mock,
+                                                    load_file_from_s3_mock, openrouter_classify_mock):
+        file_exists_in_s3_mock.return_value = True
+        upload_file_to_s3_mock.return_value = None
+        load_file_from_s3_mock.return_value = json.dumps(
+            {
+                "schema_id": "123456",
+                "schema_name": "2024 Indian Election Test",
+                "prompt": "fake prompt hehe",
+                "topics": [
+                    {
+                        "topic": "Politics",
+                        "description": "This topic includes political claims, attacks on leaders and parties, and general political commentary."
+                    },
+                    {
+                        "topic": "Democracy & Election Integrity",
+                        "description": "This topic covers the integrity of the election process, including voter fraud, election fraud, the security of voting machines, and election interference, and electoral bonds."
+                    },
+                    {
+                        "topic": "Economy & Growth",
+                        "description": "This topic covers claims around economic growth, economic policies, GDP , employment, taxation, issues among farmer and manufacturing industry, and economic inequality."
+                    },
+                    {
+                        "topic": "Communalism",
+                        "description": "This topic covers attack on religious minorities, statements on religious freedom and polarization."
+                    },
+                    {
+                        "topic": "Education",
+                        "description": "This topic covers education policy of governments, educational institutions created, and quality of education in India."
+                    },
+                    {
+                        "topic": "Freedom of Expression",
+                        "description": "This topic covers claims regarding freedom of expression and  independence of media, and attacks on press freedom and journalists."
+                    },
+                    {
+                        "topic": "Foreign Policy",
+                        "description": "This topic covers India's relationship with neighbours and other countries, claims on effectiveness of foreign policy, international image and diplomacy."
+                    },
+                    {
+                        "topic": "Safety of Women",
+                        "description": "This topic covers the issue of safety of women and steps taken to prevent crimes against women. "
+                    },
+                    {
+                        "topic": "Social Issues",
+                        "description": "This topic covers topics on the citizenship ammendmend act and caste politics."
+                    },
+                    {
+                        "topic": "Health & Pharma",
+                        "description": "This topic covers health policies, claims on ayurveda, maternal and infant mortality, and the pharmaceutical industry."
+                    },
+                    {
+                        "topic": "Terrorism & National Security",
+                        "description": "This topics covers claims on UAPA, National security, Pakistan, and terrorism."
+                    },
+                    {
+                        "topic": "Corruption",
+                        "description": "This topic covers claims on corruptions and scams."
+                    },
+                    {
+                        "topic": "History",
+                        "description": "This topic covers claim on history of India and mythology."
+                    },
+                    {
+                        "topic": "Science & Technology",
+                        "description": "This topic covers claims on climate change, environment and science."
+                    },
+                    {
+                        "topic": "Banking & Finance",
+                        "description": "This topic covers claims around finance and banking."
+                    }
+                ],
+                "examples": [
+                    {
+                        "text": "Congress Manifesto is horrible. Never seen such a dangerous manifesto in my life. It's like vision 2047 document of PFI\n\nCheck these points of manifesto\n\n1. Will bring back triple talak (Muslim personal law)\n2. Reservation to Muslim in govt n private jobs (Implement Sachchar committee report)\n3. Support Love Jihad (right to love)\n4. Support Burqa in school (right to dress)\n5. End majoritarianism (Hinduism)\n6. Ban bulldozer action\n7. Support Gaza (Hamas)\n8. Legalise Same Sex Marriage, gender fluidity, trans movement\n9. Increase Muslim judges in judiciary\n10. Communal violence bill (will stop mob lynching)\n11. Legalise beef (right to eat everything)\n12. Separate loan intrest for Muslims\n13. Allow treason (No sedition)\n\nAll those Hindu who are thinking to vote Indi Alliance, NOTA or independent. Read this and think.\n",
+                        "labels": [
+                            "Politics",
+                            "Communalism"
+                        ]
+                    },
+                    {
+                        "text": "RSS ने अपने नागपुर मुख्यालय से 2024 लोकसभा चुनाव में कॉंग्रेस गठबंधन को समर्थन करने की घोषणा की कमाल की बात ये है कि इतनी महत्वपूर्ण खबर किसी भी news channel, और अखबार ने नहीं छापी RSS ने माना कि आज नरेंद्र मोदी भाजपा सरकार में देश का संविधान और लोकतंत्र खतरे में है इसलिए भाजपा को 2024 में रोकना अति आवश्यक है अगर देश की जनता धर्म के नशे में डूबी रही तो आने वाली नस्लें तुम्हें कभी माफ़ नहीं करेगी देश आज संकट में है और जो व्यक्ति इस समय कॉंग्रेस का साथ नहीं देगा वो भविष्य में खुद को कभी माफ़ नहीं कर पाएगा इस खबर को शेयर करके देश के एक जिम्मेदार नागरिक होने का फर्ज पूरा कीजिए",
+                        "labels": [
+                            "Politics",
+                            "Democracy & Election Integrity"
+                        ]
+                    },
+                    {
+                        "text": "बेहद गंभीर मामला है। खबरों के मुताबिक, दवा बनाने वाली बहुत सी कंपनियां जिनकी दवाएं टेस्ट में फेल हुईं, इन कंपनियों ने इलेक्टोरल बॉन्ड से चंदा दिया। जैसे \uD83D\uDC47 1. गुजरात की कंपनी 'टोरेंट फार्मास्यूटिकल' की बनाई 3 दवाएं ड्रग टेस्ट में फेल हुईं। इस कंपनी ने BJP को 61 करोड़ का चंदा दिया। 2. सिप्ला लिमिटेड कंपनी की बनाई दवाओं के 7 बार ड्रग टेस्ट फ़ेल हुए। इस कंपनी ने BJP को 37 करोड़ का चंदा दिया। 3. सन फ़ार्मा कंपनी की बनाई गई दवाओं के 6 बार ड्रग टेस्ट फ़ेल हुए। सन फार्मा ने BJP को 31.5 करोड़ रुपए का चंदा दिया। 4. गुजरात की कंपनी इंटास फ़ार्मास्युटिकल्स की बनाई गई दवा का भी ड्रग टेस्ट फ़ेल हुआ। इंटास फ़ार्मा ने 20 करोड़ के इलेक्टोरल बॉन्ड ख़रीदे और सारा चंदा BJP को दिया। 5. ग्लेनमार्क फ़ार्मा कंपनी की दवाओं के 6 ड्रग टेस्ट फ़ेल हुए। ग्लेनमार्क फ़ार्मा 9.75 करोड़ रुपए के बॉन्ड ख़रीदे और सारा चंदा BJP को दिया।",
+                        "labels": [
+                            "Corruption",
+                            "Health & Pharma",
+                            "Politics"
+                        ]
+                    },
+                    {
+                        "text": "യുഎഇ അബുദാബിയിലെയും ദുബായിലെയും എല്ലാ അറബ് മന്ത്രിമാരും അറബ് ഷേക്'മാരും റമദാൻ മാസത്തിൽ ഇന്ന് അബുദാബി ഹിന്ദു ക്ഷേത്രത്തിലെത്തി പ്രസാദത്തോടെ ക്ഷേത്രത്തിൽ റമദാൻ വ്രതം പൂർത്തിയാക്കി. (ഇതൊരു വലിയ അത്ഭുതമാണ്.) ഈ വീഡിയോ കാണുക.\uD83D\uDEA9\uD83D\uDEA9\uD83D\uDEA9\n\n",
+                        "labels": [
+                            "Foreign Policy",
+                            "Politics",
+                            "Communalism"
+                        ]
+                    }
+                ],
+                "languages": [
+                    "English",
+                    "Hindi",
+                    "Telugu",
+                    "Malayalam"
+                ]
+            }
+        )
+        openrouter_classify_mock.return_value = "<OUTPUT>\n<CATEGORIES_0>Politico;Communism</CATEGORIES_0>\n<CATEGORIES_1>Politico;Communism</CATEGORIES_1>\n</OUTPUT>"
+        classify_input = {
+            "model_name": "classycat__Model",
+            "body": {
+                "id": 1200,
+                "parameters": {
+                    "event_type": "classify",
+                    "schema_id": "4a026b82-4a16-440d-aed7-bec07af12205",
+                    "items": [
+                        {
+                            "id": "11",
+                            "text": "modi and bjp want to rule india by dividing people against each other"
+                        },
+                        {
+                            "id": "12",
+                            "text": "modi and bjp are amazing politicians"
+                        }
+                    ]
+                },
+                "callback_url": "http://example.com?callback"
+            }
+        }
+        classify_message = schemas.parse_message(classify_input)
+        result = self.classycat_model.process(classify_message)
+
+        self.assertIn("Error classifying items: No items were classified successfully", result.responseMessage)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/lib/model/test_classycat.py
+++ b/test/lib/model/test_classycat.py
@@ -819,7 +819,7 @@ class TestClassyCat(TestCase):
                 ]
             }
         )
-        openrouter_classify_mock.return_value = "<OUTPUT>\n<CATEGORIES_0>Politics;Communalism</CATEGORIES_0>\n<CATEGORIES_1>Politico;Communism</CATEGORIES_1>\n</OUTPUT>"
+        openrouter_classify_mock.return_value = "<OUTPUT>\n<CATEGORIES_0>Politics;Communalism</CATEGORIES_0>\n<CATEGORIES_1>Politico;Communism</CATEGORIES_1>\n<CATEGORIES_2>Politics;Communism</CATEGORIES_2>\n</OUTPUT>"
         classify_input = {
             "model_name": "classycat__Model",
             "body": {
@@ -835,6 +835,10 @@ class TestClassyCat(TestCase):
                         {
                             "id": "12",
                             "text": "modi and bjp are amazing politicians"
+                        },
+                        {
+                            "id": "13",
+                            "text": "modi is an amazing politician"
                         }
                     ]
                 },
@@ -845,7 +849,10 @@ class TestClassyCat(TestCase):
         result = self.classycat_model.process(classify_message)
 
         self.assertEqual("success", result.responseMessage)
-        self.assertEqual(1, len(result.classification_results))
+        self.assertEqual(3, len(result.classification_results))
+        self.assertListEqual(["Politics", "Communalism"], result.classification_results[0]['labels'])
+        self.assertListEqual([], result.classification_results[1]['labels'])
+        self.assertListEqual(["Politics"], result.classification_results[2]['labels'])
 
     @patch('lib.model.classycat_classify.OpenRouterClient.classify')
     @patch('lib.model.classycat_classify.load_file_from_s3')
@@ -987,7 +994,10 @@ class TestClassyCat(TestCase):
         classify_message = schemas.parse_message(classify_input)
         result = self.classycat_model.process(classify_message)
 
-        self.assertIn("Error classifying items: No items were classified successfully", result.responseMessage)
+        self.assertEqual("success", result.responseMessage)
+        self.assertEqual(2, len(result.classification_results))
+        self.assertListEqual([], result.classification_results[0]['labels'])
+        self.assertListEqual([], result.classification_results[1]['labels'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
Code and tests for verifying the returned labels belong to the same set as defined in the classycat schema.
In case some items in a batch have out-of-schema labels, those items will be omitted from the results, however the rest of items that were classified as expected will be returned. In case all the generated labels are out of schema, an error will be returned, marking the operation as failure.

Reference: [CV2-4801](https://meedan.atlassian.net/jira/software/c/projects/CV2/issues/CV2-4801)

## How has this been tested?
Has been tested locally and through unit tests.
However the condition where LLM returns out of schema labels is difficult to control and reproduce.
But the scenario has been reproduced in unit tests and it's verified the code functions as expected in case of out of schema labels.

## Are there any external dependencies?
This code requires classycat functionality in presto to be deployed and builds on top of the classycat branch

## Have you considered secure coding practices when writing this code?
No concerns


[CV2-4801]: https://meedan.atlassian.net/browse/CV2-4801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ