### PR TITLE
CV2-4952: ClassyCat Error Handling and Metrics

### DIFF
--- a/lib/base_exception.py
+++ b/lib/base_exception.py
@@ -1,0 +1,8 @@
+class PrestoBaseException(Exception):
+    def __init__(self, message: str, error_code: int = 500):
+        self.message = message
+        self.error_code = error_code
+        super().__init__(message)
+
+    def __str__(self):
+        return f"{self.error_code}: {self.message}"

--- a/lib/model/classycat.py
+++ b/lib/model/classycat.py
@@ -23,5 +23,3 @@ class Model(Model):
         else:
             logger.error(f"Unknown event type {event_type}")
             raise PrestoBaseException(f"Unknown event type {event_type}", 422)
-            # message.body.result.responseMessage = f"Unknown event type {event_type}"
-            # return message.body.result

--- a/lib/model/classycat.py
+++ b/lib/model/classycat.py
@@ -5,6 +5,7 @@ from lib.schemas import Message, ClassyCatSchemaResponse, ClassyCatBatchClassifi
 from lib.model.classycat_classify import Model as ClassifyModel
 from lib.model.classycat_schema_create import Model as ClassyCatSchemaCreateModel
 from lib.model.classycat_schema_lookup import Model as ClassyCatSchemaLookupModel
+from lib.base_exception import PrestoBaseException
 
 
 class Model(Model):
@@ -21,5 +22,6 @@ class Model(Model):
             return ClassyCatSchemaCreateModel().process(message)
         else:
             logger.error(f"Unknown event type {event_type}")
-            message.body.result.responseMessage = f"Unknown event type {event_type}"
-            return message.body.result
+            raise PrestoBaseException(f"Unknown event type {event_type}", 422)
+            # message.body.result.responseMessage = f"Unknown event type {event_type}"
+            # return message.body.result

--- a/lib/model/classycat_classify.py
+++ b/lib/model/classycat_classify.py
@@ -66,7 +66,9 @@ class OpenRouterClient(LLMClient):
             max_tokens=(max_tokens_per_item * items_count) + 15,
             temperature=0.5
         )
-# TODO: record metric here with model name and number of items submitted (https://meedan.atlassian.net/browse/CV2-4987)
+
+        # TODO: record metric here with model name and number of items submitted (https://meedan.atlassian.net/browse/CV2-4987)
+
         return completion.choices[0].message.content
 
 

--- a/lib/model/classycat_schema_lookup.py
+++ b/lib/model/classycat_schema_lookup.py
@@ -4,6 +4,7 @@ from lib.logger import logger
 from lib.model.model import Model
 from lib.s3 import load_file_from_s3, file_exists_in_s3
 from lib.schemas import Message, ClassyCatSchemaResponse
+from lib.base_exception import PrestoBaseException
 
 
 class Model(Model):
@@ -63,8 +64,7 @@ class Model(Model):
         result = message.body.result
 
         if not self.schema_name_exists(schema_name):
-            result.responseMessage = f"Schema name {schema_name} does not exist"
-            return result
+            raise PrestoBaseException(f"Schema name {schema_name} does not exist", 404)
 
         logger.debug(f"located schema_name record for '{schema_name}'")
 
@@ -74,5 +74,4 @@ class Model(Model):
             return result
         except Exception as e:
             logger.error(f"Error looking up schema name {schema_name}: {e}")
-            result.responseMessage = f"Error looking up schema name {schema_name}: {e}"
-            return result
+            raise PrestoBaseException(f"Error looking up schema name {schema_name}", 500) from e

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -55,7 +55,7 @@ class Model(ABC):
                     error_context[attr] = '\n'.join(traceback.format_tb(getattr(e, attr)))
                 else:
                     error_context[attr] = str(getattr(e, attr))
-        capture_custom_message(f"Error during fingerprinting for {self.model_name}", 'info', error_context)
+        capture_custom_message(f"Error during fingerprinting for {self.model_name}", 'error', error_context)
         return schemas.ErrorResponse(error=str(e), error_details=error_context, error_code=response_code)
 
     def get_response(self, message: schemas.Message) -> schemas.GenericItem:  # TODO note: the return type is wrong here

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -10,9 +10,12 @@ from lib.helpers import get_class
 from lib import schemas
 from lib.cache import Cache
 from lib.sentry import capture_custom_message
+from lib.base_exception import PrestoBaseException
+
 
 class Model(ABC):
     BATCH_SIZE = 1
+
     def __init__(self):
         self.model_name = os.environ.get("MODEL_NAME")
 
@@ -43,7 +46,7 @@ class Model(ABC):
     def process(self, messages: Union[List[schemas.Message], schemas.Message]) -> List[schemas.Message]:
         return []
 
-    def handle_fingerprinting_error(self, e):
+    def handle_fingerprinting_error(self, e: Exception, response_code: int = 500) -> schemas.ErrorResponse:
         error_context = {"error": str(e)}
         for attr in ["__cause__", "__context__", "args", "__traceback__"]:
             if attr in dir(e):
@@ -52,7 +55,7 @@ class Model(ABC):
                 else:
                     error_context[attr] = getattr(e, attr)
         capture_custom_message("Error during fingerprinting for {self.model_name}", 'info', error_context)
-        return schemas.ErrorResponse(error=str(e), error_details=error_context)
+        return schemas.ErrorResponse(error=str(e), error_details=error_context, error_code=response_code)
 
     def get_response(self, message: schemas.Message) -> schemas.GenericItem:
         """
@@ -64,7 +67,10 @@ class Model(ABC):
                 result = self.process(message)
                 Cache.set_cached_result(message.body.content_hash, result)
             except Exception as e:
-                return self.handle_fingerprinting_error(e)
+                if isinstance(e, PrestoBaseException):
+                    return self.handle_fingerprinting_error(e, e.error_code)
+                else:
+                    return self.handle_fingerprinting_error(e)
         return result
 
     def respond(self, messages: Union[List[schemas.Message], schemas.Message]) -> List[schemas.Message]:
@@ -76,7 +82,7 @@ class Model(ABC):
         for message in messages:
             message.body.result = self.get_response(message)
         return messages
-    
+
     @classmethod
     def create(cls):
         """

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -55,7 +55,7 @@ class Model(ABC):
                     error_context[attr] = '\n'.join(traceback.format_tb(getattr(e, attr)))
                 else:
                     error_context[attr] = str(getattr(e, attr))
-        capture_custom_message("Error during fingerprinting for {self.model_name}", 'info', error_context)
+        capture_custom_message(f"Error during fingerprinting for {self.model_name}", 'info', error_context)
         return schemas.ErrorResponse(error=str(e), error_details=error_context, error_code=response_code)
 
     def get_response(self, message: schemas.Message) -> schemas.GenericItem:  # TODO note: the return type is wrong here

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -11,7 +11,6 @@ from lib import schemas
 from lib.cache import Cache
 from lib.sentry import capture_custom_message
 from lib.base_exception import PrestoBaseException
-from lib.logger import logger
 
 
 class Model(ABC):

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -58,7 +58,7 @@ class Model(ABC):
         capture_custom_message("Error during fingerprinting for {self.model_name}", 'info', error_context)
         return schemas.ErrorResponse(error=str(e), error_details=error_context, error_code=response_code)
 
-    def get_response(self, message: schemas.Message) -> Union[schemas.GenericItem, schemas.ErrorResponse]:
+    def get_response(self, message: schemas.Message) -> schemas.GenericItem:  # TODO note: the return type is wrong here
         """
         Perform a lookup on the cache for a message, and if found, return that cached value.
         """

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -54,7 +54,7 @@ class Model(ABC):
                 if attr == "__traceback__":
                     error_context[attr] = '\n'.join(traceback.format_tb(getattr(e, attr)))
                 else:
-                    error_context[attr] = getattr(e, attr)
+                    error_context[attr] = str(getattr(e, attr))
         capture_custom_message("Error during fingerprinting for {self.model_name}", 'info', error_context)
         return schemas.ErrorResponse(error=str(e), error_details=error_context, error_code=response_code)
 

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -11,6 +11,7 @@ from lib import schemas
 from lib.cache import Cache
 from lib.sentry import capture_custom_message
 from lib.base_exception import PrestoBaseException
+from lib.logger import logger
 
 
 class Model(ABC):
@@ -57,7 +58,7 @@ class Model(ABC):
         capture_custom_message("Error during fingerprinting for {self.model_name}", 'info', error_context)
         return schemas.ErrorResponse(error=str(e), error_details=error_context, error_code=response_code)
 
-    def get_response(self, message: schemas.Message) -> schemas.GenericItem:
+    def get_response(self, message: schemas.Message) -> Union[schemas.GenericItem, schemas.ErrorResponse]:
         """
         Perform a lookup on the cache for a message, and if found, return that cached value.
         """

--- a/lib/queue/processor.py
+++ b/lib/queue/processor.py
@@ -44,7 +44,7 @@ class QueueProcessor(Queue):
         if messages_with_queues:
             logger.info(f"About to respond to: ({messages_with_queues})")
             bodies = [
-                schemas.parse_message(json.loads(message.body))
+                json.loads(message.body)
                 for message, queue in messages_with_queues
             ]
             for body in bodies:
@@ -58,10 +58,11 @@ class QueueProcessor(Queue):
         """
         logger.info(f"Message for callback is: {message}")
         try:
-            callback_url = message.body.callback_url
+            callback_url = message['body']['callback_url']
+            # callback_url = message.body.callback_url
             response = requests.post(
                 callback_url,
-                json=message.dict(),
+                json=message,
                 # headers={"Content-Type": "application/json"},
             )
             # check for error with the callback

--- a/test/lib/model/test_classycat.py
+++ b/test/lib/model/test_classycat.py
@@ -564,14 +564,8 @@ class TestClassyCat(TestCase):
         }
         classify_message = schemas.parse_message(classify_input)
 
-        try:
-            result = self.classycat_model.process(classify_message)
-            # fail tests here if no exception is raised
-            self.fail("Expected exception")
-        except Exception as e:
-            if not isinstance(e, PrestoBaseException):
-                self.fail("Expected PrestoBaseException")
-
+        with self.assertRaises(PrestoBaseException) as e:
+            self.classycat_model.process(classify_message)
             self.assertIn("Error classifying items: list index out of range", e.message)
             self.assertEqual(e.error_code, 500)
 
@@ -710,14 +704,8 @@ class TestClassyCat(TestCase):
         }
         classify_message = schemas.parse_message(classify_input)
 
-        try:
-            result = self.classycat_model.process(classify_message)
-            # fail tests here if no exception is raised
-            self.fail("Expected exception")
-        except Exception as e:
-            if not isinstance(e, PrestoBaseException):
-                self.fail("Expected PrestoBaseException")
-
+        with self.assertRaises(PrestoBaseException) as e:
+            self.classycat_model.process(classify_message)
             self.assertIn("Not all items were classified successfully: input length 1, output length 2", e.message)
             self.assertEqual(e.error_code, 502)
 
@@ -726,7 +714,7 @@ class TestClassyCat(TestCase):
     @patch('lib.model.classycat_classify.load_file_from_s3')
     @patch('lib.model.classycat_classify.upload_file_to_s3')
     @patch('lib.model.classycat_classify.file_exists_in_s3')
-    def test_classify_pass_some_out_of_schema_labels(self, file_exists_in_s3_mock, upload_file_to_s3_mock,
+    def test_classify_some_out_of_schema_labels(self, file_exists_in_s3_mock, upload_file_to_s3_mock,
                                                      load_file_from_s3_mock, openrouter_classify_mock):
         file_exists_in_s3_mock.return_value = True
         upload_file_to_s3_mock.return_value = None
@@ -876,7 +864,7 @@ class TestClassyCat(TestCase):
     @patch('lib.model.classycat_classify.load_file_from_s3')
     @patch('lib.model.classycat_classify.upload_file_to_s3')
     @patch('lib.model.classycat_classify.file_exists_in_s3')
-    def test_classify_fail_all_out_of_schema_labels(self, file_exists_in_s3_mock, upload_file_to_s3_mock,
+    def test_classify_all_out_of_schema_labels(self, file_exists_in_s3_mock, upload_file_to_s3_mock,
                                                     load_file_from_s3_mock, openrouter_classify_mock):
         file_exists_in_s3_mock.return_value = True
         upload_file_to_s3_mock.return_value = None

--- a/test/lib/model/test_classycat.py
+++ b/test/lib/model/test_classycat.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 from lib.model.classycat import Model as ClassyCatModel
 from lib import schemas
+from lib.base_exception import PrestoBaseException
 import json
 
 
@@ -562,9 +563,17 @@ class TestClassyCat(TestCase):
             }
         }
         classify_message = schemas.parse_message(classify_input)
-        result = self.classycat_model.process(classify_message)
 
-        self.assertEqual(result.responseMessage, "Error classifying items: list index out of range")
+        try:
+            result = self.classycat_model.process(classify_message)
+            # fail tests here if no exception is raised
+            self.fail("Expected exception")
+        except Exception as e:
+            if not isinstance(e, PrestoBaseException):
+                self.fail("Expected PrestoBaseException")
+
+            self.assertIn("Error classifying items: list index out of range", e.message)
+            self.assertEqual(e.error_code, 500)
 
     @patch('lib.model.classycat_classify.OpenRouterClient.classify')
     @patch('lib.model.classycat_classify.load_file_from_s3')
@@ -700,9 +709,18 @@ class TestClassyCat(TestCase):
             }
         }
         classify_message = schemas.parse_message(classify_input)
-        result = self.classycat_model.process(classify_message)
 
-        self.assertEqual(result.responseMessage, "Error classifying items: Not all items were classified successfully: input length 1, output length 2")
+        try:
+            result = self.classycat_model.process(classify_message)
+            # fail tests here if no exception is raised
+            self.fail("Expected exception")
+        except Exception as e:
+            if not isinstance(e, PrestoBaseException):
+                self.fail("Expected PrestoBaseException")
+
+            self.assertIn("Not all items were classified successfully: input length 1, output length 2", e.message)
+            self.assertEqual(e.error_code, 502)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
Error handling for ClassyCat using new error handling / exception mechanisms in Presto
ClassyCat modules now raise unhandled "PrestoBaseException" objects that include an http error code to properly respond to consumer requests.

Reference: [CV2-4952](https://meedan.atlassian.net/jira/software/c/projects/CV2/issues/CV2-4952)

## How has this been tested?
Has been tested locally and in unit tests

## Are there any external dependencies?
No

## Have you considered secure coding practices when writing this code?
We return stack traces included in error messages, which raises security concerns.


[CV2-4952]: https://meedan.atlassian.net/browse/CV2-4952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ