### PR TITLE
CV2-5101 i think you can just.... delete the subclass function and it'll just work?

### DIFF
--- a/lib/model/generic_transformer.py
+++ b/lib/model/generic_transformer.py
@@ -75,10 +75,3 @@ class GenericTransformerModel(Model):
         Vectorize the text! Run as batch.
         """
         return self.model.encode(texts).tolist()
-
-    def handle_fingerprinting_error(self, error: Exception):
-        """
-        Handle any error that occurs during vectorization.
-        """
-        logger.error(f"Error during vectorization: {error}")
-        raise error

--- a/lib/model/generic_transformer.py
+++ b/lib/model/generic_transformer.py
@@ -75,3 +75,4 @@ class GenericTransformerModel(Model):
         Vectorize the text! Run as batch.
         """
         return self.model.encode(texts).tolist()
+

--- a/test/lib/model/test_generic.py
+++ b/test/lib/model/test_generic.py
@@ -1,3 +1,4 @@
+import traceback
 import os
 import unittest
 from unittest.mock import MagicMock, patch
@@ -108,13 +109,11 @@ class TestGenericTransformerModel(unittest.TestCase):
             self.assertEqual(texts_to_vectorize[0], "Hello")
             self.assertEqual(docs[1].body.result, [4, 5, 6])
 
-    @patch('lib.model.generic_transformer.logger')
-    def test_handle_fingerprinting_error(self, mock_logger):
-        with self.assertRaises(Exception) as context:
-            self.model.handle_fingerprinting_error(ValueError("An error occurred"))
-        
-        mock_logger.error.assert_called_once_with("Error during vectorization: An error occurred")
-        self.assertTrue(isinstance(context.exception, ValueError))
+    @patch('lib.sentry.capture_custom_message')
+    def test_handle_fingerprinting_error(self, mock_capture_custom_message):
+        error = ValueError("An error occurred")
+        response = self.model.handle_fingerprinting_error(error)
+        self.assertIsInstance(response, schemas.ErrorResponse)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
Brings text errors back in line with other fingerprinting errors

Reference: CV2-5101

## How has this been tested?
Not yet tested locally

## Are there any external dependencies?
No dependency change

## Have you considered secure coding practices when writing this code?
No security change.
