### PR TITLE
CV2-5247-support-yake-keyword-extraction-for-chinese

### DIFF
--- a/lib/model/yake_keywords.py
+++ b/lib/model/yake_keywords.py
@@ -38,7 +38,7 @@ class Model(Model):
         return text
 
     def run_chinese_segmentation_with_jieba(self, text):
-        return " ".join(list(jieba.cut_for_search(text)))
+        return " ".join(list(jieba.cut(text)))
     
     def run_yake(self, text: str,
                  language: str,

--- a/test/lib/model/test_yake_keywords.py
+++ b/test/lib/model/test_yake_keywords.py
@@ -55,7 +55,7 @@ class TestYakeKeywordsModel(unittest.TestCase):
 
     def test_run_chinese_segmentation_with_jieba(self):
         test_text = '''哈里斯同意与特朗普再进行一次美大选辩论'''
-        expected = "哈里 里斯 哈里斯 同意 与 特朗普 再 进行 一次 美 大选 辩论"
+        expected = "哈里斯 同意 与 特朗普 再 进行 一次 美 大选 辩论"
         self.assertEqual(self.yake_model.run_chinese_segmentation_with_jieba(test_text), expected)
 
     def test_run_yake_real_with_chinese(self):


### PR DESCRIPTION
## Description
Fix for CV2-5247-support-yake-keyword-extraction-for-chinese 
to change jieba's function call `cut_for_search` to `cut` 

Reference: CV2-5247

## How has this been tested?
Has it been tested locally? Are there automated tests?
both. 
