### PR TITLE
CV2-5050 add additional context when transformer vectorization fails

### DIFF
--- a/lib/model/generic_transformer.py
+++ b/lib/model/generic_transformer.py
@@ -69,7 +69,7 @@ class GenericTransformerModel(Model):
                 doc.body.result = vector
                 Cache.set_cached_result(doc.body.content_hash, vector)
         except Exception as e:
-            self.handle_fingerprinting_error(e)
+            self.handle_fingerprinting_error(e, 500, {"texts_to_vectorize": texts_to_vectorize})
 
     def vectorize(self, texts: List[str]) -> List[List[float]]:
         """

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -46,7 +46,7 @@ class Model(ABC):
     def process(self, messages: Union[List[schemas.Message], schemas.Message]) -> List[schemas.Message]:
         return []
 
-    def handle_fingerprinting_error(self, e: Exception, response_code: int = 500) -> schemas.ErrorResponse:
+    def handle_fingerprinting_error(self, e: Exception, response_code: int = 500, additional_context: dict = {}) -> schemas.ErrorResponse:
         error_context = {"error": str(e)}
         for attr in ["__cause__", "__context__", "args", "__traceback__"]:
             if attr in dir(e):
@@ -54,6 +54,8 @@ class Model(ABC):
                     error_context[attr] = '\n'.join(traceback.format_tb(getattr(e, attr)))
                 else:
                     error_context[attr] = str(getattr(e, attr))
+        for k,v in additional_context.items():
+            error_context[k] = v
         capture_custom_message(f"Error during fingerprinting for {self.model_name}", 'error', error_context)
         return schemas.ErrorResponse(error=str(e), error_details=error_context, error_code=response_code)
 


### PR DESCRIPTION
## Description
Adds additional context dict to inject function-level context if/when valuable to reproduce specific errors

Reference: CV2-5050

## How has this been tested?
Tested in QA and confirmed to pipe the correct data through to sentry

## Are there any external dependencies?
None

## Have you considered secure coding practices when writing this code?
None
