### PR TITLE
CV2-5589 add explicit timeout

### DIFF
--- a/lib/queue/processor.py
+++ b/lib/queue/processor.py
@@ -1,6 +1,6 @@
 from typing import List
 import json
-
+from datetime import datetime
 import requests
 
 from lib import schemas
@@ -60,15 +60,17 @@ class QueueProcessor(Queue):
         try:
             schemas.parse_output_message(message)  # will raise exceptions if not valid, e.g. too large of a message
             callback_url = message.get("body", {}).get("callback_url")
+            start_time = datetime.now()
             response = requests.post(
                 callback_url,
+                timeout=30,
                 json=message,
                 # headers={"Content-Type": "application/json"},
             )
-            # check for error with the callback
             if response.ok != True:
                 logger.error(f"Callback error responding to {callback_url} :{response}")
         except Exception as e:
+            duration = (datetime.now() - start_time).total_seconds()
             logger.error(
-                f"Callback fail! Failed with {e} on {callback_url} with message of {message}"
+                f"Callback fail! Failed with {e} on {callback_url} with message of {message}, duration was {duration}"
             )

--- a/test/lib/queue/test_processor.py
+++ b/test/lib/queue/test_processor.py
@@ -40,7 +40,7 @@ class TestQueueProcessor(unittest.TestCase):
     def test_send_callback(self, mock_post):
         message_body = {"body": {"callback_url": "http://example.com", "text": "This is a test", "id": 123, "result": {"hash_value": [1,2,3]}}, "model_name": "mean_tokens__Model"}
         self.queue_processor.send_callback(message_body)
-        mock_post.assert_called_once_with("http://example.com", json=message_body)
+        mock_post.assert_called_once_with("http://example.com", timeout=30, json=message_body)
 
     @patch('lib.queue.processor.requests.post')
     def test_send_callback_failure(self, mock_post):


### PR DESCRIPTION
## Description
Adds 30s timeout and some logs to help diagnose long running callbacks

Reference: CV2-5589

## How has this been tested?
Not tested locally

## Are there any external dependencies?
Nope!

## Have you considered secure coding practices when writing this code?
None
