### PR TITLE
refactor to get rid of persistent queues and change to singular lookup

### DIFF
--- a/lib/queue/queue.py
+++ b/lib/queue/queue.py
@@ -19,7 +19,6 @@ class Queue:
         Start a specific queue - must pass input_queue_name.
         """
         self.sqs_lock = Lock()
-        self.sqs = self.get_sqs()
 
     @staticmethod
     def get_queue_prefix():
@@ -82,7 +81,7 @@ class Queue:
             # Optionally enable content-based deduplication for FIFO queues
             attributes['ContentBasedDeduplication'] = 'true'
             # Include other FIFO-specific attributes as needed
-        return self.sqs.create_queue(
+        return self.get_sqs().create_queue(
             QueueName=queue_name,
             Attributes=attributes
         )
@@ -92,14 +91,7 @@ class Queue:
         Initialize all queues for the given worker - try to create them if they are not found by name for whatever reason
         """
         try:
-            found_queues = [q for q in self.sqs.queues.filter(QueueNamePrefix=queue_name)]
-            exact_match_queues = [queue for queue in found_queues if queue.attributes['QueueArn'].split(':')[-1] == queue_name]
-            logger.info(f"found queues are {found_queues}")
-            logger.info(f"exact queues are {exact_match_queues}")
-            if exact_match_queues:
-                return exact_match_queues
-            else:
-                return [self.create_queue(queue_name)]
+            return [self.get_sqs().get_queue_by_name(QueueName=queue_name)]
         except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == "AWS.SimpleQueueService.NonExistentQueue":
                 return [self.create_queue(queue_name)]

--- a/test/lib/queue/test_processor.py
+++ b/test/lib/queue/test_processor.py
@@ -16,7 +16,7 @@ class TestQueueProcessor(unittest.TestCase):
         self.mock_sqs_resource = MagicMock()
         self.mock_input_queue = MagicMock()
         self.mock_input_queue.url = "http://queue/mean_tokens__Model"
-        self.mock_sqs_resource.queues.filter.return_value = [self.mock_input_queue]
+        self.mock_sqs_resource.get_queue_by_name.return_value = self.mock_input_queue
         mock_boto_resource.return_value = self.mock_sqs_resource
 
         # Initialize the QueueProcessor instance

--- a/test/lib/queue/test_queue.py
+++ b/test/lib/queue/test_queue.py
@@ -49,7 +49,7 @@ class TestQueueWorker(unittest.TestCase):
         self.mock_dlq_queue = MagicMock()
         self.mock_dlq_queue.url = f"http://queue/{self.queue_name_dlq}"
         self.mock_dlq_queue.attributes = {"QueueArn": f"queue:{self.queue_name_dlq}"}
-        self.mock_sqs_resource.queues.filter.return_value = [self.mock_input_queue, self.mock_output_queue, self.mock_dlq_queue]
+        self.mock_sqs_resource.get_queue_by_name.return_value = self.mock_input_queue#[, self.mock_output_queue, self.mock_dlq_queue]
         mock_boto_resource.return_value = self.mock_sqs_resource
 
         # Initialize the QueueWorker instance

--- a/test/lib/queue/test_queue.py
+++ b/test/lib/queue/test_queue.py
@@ -49,7 +49,11 @@ class TestQueueWorker(unittest.TestCase):
         self.mock_dlq_queue = MagicMock()
         self.mock_dlq_queue.url = f"http://queue/{self.queue_name_dlq}"
         self.mock_dlq_queue.attributes = {"QueueArn": f"queue:{self.queue_name_dlq}"}
-        self.mock_sqs_resource.get_queue_by_name.return_value = self.mock_input_queue#[, self.mock_output_queue, self.mock_dlq_queue]
+        self.mock_sqs_resource.get_queue_by_name.side_effect = lambda QueueName: {
+            self.queue_name_input: self.mock_input_queue,
+            self.queue_name_output: self.mock_output_queue,
+            self.queue_name_dlq: self.mock_dlq_queue
+        }.get(QueueName)
         mock_boto_resource.return_value = self.mock_sqs_resource
 
         # Initialize the QueueWorker instance


### PR DESCRIPTION
## Description
Queues could theoretically get wonky with long-held state, and also we could be more specific when selecting queues by using singular access instead of filters.

Reference: CV2-5589

## How has this been tested?
Not tested locally yet

## Are there any external dependencies?
Nothing changes in this PR

## Have you considered secure coding practices when writing this code?
Nothing changes in this PR
