### PR TITLE
CV2-5589 reverts accidental regression

### DIFF
--- a/lib/queue/queue.py
+++ b/lib/queue/queue.py
@@ -170,7 +170,7 @@ class Queue:
         Receive messages from a queue.
         """
         queue = self.get_or_create_queue(self.input_queue_name)[0]
-        return queue.receive_messages(MaxNumberOfMessages=min(batch_size, SQS_MAX_BATCH_SIZE))
+        return [(m, self.input_queue_name) for m in queue.receive_messages(MaxNumberOfMessages=min(batch_size, SQS_MAX_BATCH_SIZE))]
 
     def find_queue_by_name(self, queue_name: str) -> boto3.resources.base.ServiceResource:
         """

--- a/test/lib/queue/test_queue.py
+++ b/test/lib/queue/test_queue.py
@@ -125,8 +125,8 @@ class TestQueueWorker(unittest.TestCase):
         received_messages = self.queue.receive_messages(5)
         # Assertions
         self.assertEqual(len(received_messages), 2)
-        self.assertIn("a test", json.loads(received_messages[0].body)["body"]["text"])
-        self.assertIn("another test", json.loads(received_messages[1].body)["body"]["text"])
+        self.assertIn("a test", json.loads(received_messages[0][0].body)["body"]["text"])
+        self.assertIn("another test", json.loads(received_messages[1][0].body)["body"]["text"])
 
     def test_restrict_queues_by_suffix(self):
         queues = [


### PR DESCRIPTION
## Description
Reverts regression on structure of receive_messages which returns tuples, and changed as a result of moving to singular queue responses

Reference: CV2-5589

## How has this been tested?
Tests confirm this was a regression - other tests really should have caught this outside just the singular case

## Are there any external dependencies?
None

## Have you considered secure coding practices when writing this code?
None
