### PR TITLE
CV2-5709 wrap processor run within worker status check

### DIFF
--- a/start_all.sh
+++ b/start_all.sh
@@ -21,7 +21,7 @@ if [ "$ROLE" = "worker" ]; then
       done
     ) &  # Run workers as background processes
   done
-fi
 
-# Start the processor process in the foreground
-python run_processor.py
+  # Start the processor process in the foreground
+  python run_processor.py
+fi


### PR DESCRIPTION
## Description
Wraps processor (which is the _other_ "listening to queues..." functionality) to only run on worker instances

Reference: CV2-5709

## How has this been tested?
none

## Are there any external dependencies?
none

## Have you considered secure coding practices when writing this code?
none
