### PR TITLE
Bugfix on start script to ensure we do not run worker or processor in server role tasks

### DIFF
--- a/start_all.sh
+++ b/start_all.sh
@@ -4,10 +4,8 @@ if [ "$ROLE" != "worker" ]; then
   # Start the HTTP server process in the background if not a worker
   uvicorn main:app --host 0.0.0.0 --port ${PRESTO_PORT} --reload
 
-fi
-
-if [ "$ROLE" == "worker" ]; then
-  # Start worker processes
+else
+  # Start worker processes in background
   NUM_WORKERS=${NUM_WORKERS:-1}  # Default to 1 worker if not specified
 
   for i in $(seq 1 $NUM_WORKERS)


### PR DESCRIPTION
## Description

Bug fix for not running worker or processor when running Presto in server role.

Reference: CV2-5119

## How has this been tested?
Tested locally

## Have you considered secure coding practices when writing this code?
No security concerns with this change.