### PR TITLE
CV2-5726 don't use reload flag when running the server in the cloud

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
-.PHONY: run run_http run_worker run_test
+.PHONY: run run_http run_worker run_processor run_test
 
 run:
 	./start_all.sh
 
 run_http:
+ifeq ($(filter $(DEPLOY_ENV),qa live),)
 	uvicorn main:app --host 0.0.0.0 --reload
+else
+	uvicorn main:app --host 0.0.0.0
+endif
 
 run_worker:
 	python run_worker.py


### PR DESCRIPTION
## Description
We use `--reload` when we really shouldn't in production on Presto - it slows requests down and the server will, by definition, never reload.

Reference: CV2-5726

## How has this been tested?
Not tested locally, by definition, since this applies to prod

## Are there any external dependencies?
None

## Have you considered secure coding practices when writing this code?
None