### PR TITLE
CV2-5639 add sleep during message receives

### DIFF
--- a/lib/queue/queue.py
+++ b/lib/queue/queue.py
@@ -1,4 +1,5 @@
 import json
+import time
 from typing import List, Dict, Tuple
 import os
 import threading
@@ -170,6 +171,7 @@ class Queue:
         Receive messages from a queue.
         """
         queue = self.get_or_create_queue(self.input_queue_name)[0]
+        time.sleep(0.5)
         return [(m, self.input_queue_name) for m in queue.receive_messages(MaxNumberOfMessages=min(batch_size, SQS_MAX_BATCH_SIZE))]
 
     def find_queue_by_name(self, queue_name: str) -> boto3.resources.base.ServiceResource:


### PR DESCRIPTION
## Description
We hemorrhage a ton of `EmptyReceives` when requesting messages via SQS - this PR slows down the requestor to an amount that is negligible for us, but will greatly reduce ridiculous levels of needless spend.

Reference: CV2-5639

## How has this been tested?
By its nature this is a remote/cloud issue

## Are there any external dependencies?
none

## Have you considered secure coding practices when writing this code?
none
