### PR TITLE
CV2-5789 pack in more context for error states on presto

### DIFF
--- a/lib/model/generic_transformer.py
+++ b/lib/model/generic_transformer.py
@@ -64,13 +64,12 @@ class GenericTransformerModel(Model):
         Vectorize the uncached texts and store the results in the cache.
         """
         try:
-            
             vectorized = self.vectorize(texts_to_vectorize)
             for doc, vector in zip(docs_to_process, vectorized):
                 doc.body.result = vector
                 Cache.set_cached_result(doc.body.content_hash, vector)
         except Exception as e:
-            self.handle_fingerprinting_error(e, 500, {"texts_to_vectorize": texts_to_vectorize, "docs_to_process": [e.body for e in docs_to_process]})
+            self.handle_fingerprinting_error(e, 500, {"texts_to_vectorize": texts_to_vectorize, "docs_to_process": [e.body.model_dump() for e in docs_to_process]})
 
     def vectorize(self, texts: List[str]) -> List[List[float]]:
         """

--- a/lib/model/generic_transformer.py
+++ b/lib/model/generic_transformer.py
@@ -64,12 +64,13 @@ class GenericTransformerModel(Model):
         Vectorize the uncached texts and store the results in the cache.
         """
         try:
+            
             vectorized = self.vectorize(texts_to_vectorize)
             for doc, vector in zip(docs_to_process, vectorized):
                 doc.body.result = vector
                 Cache.set_cached_result(doc.body.content_hash, vector)
         except Exception as e:
-            self.handle_fingerprinting_error(e, 500, {"texts_to_vectorize": texts_to_vectorize})
+            self.handle_fingerprinting_error(e, 500, {"texts_to_vectorize": texts_to_vectorize, "docs_to_process": [e.body for e in docs_to_process]})
 
     def vectorize(self, texts: List[str]) -> List[List[float]]:
         """

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -70,9 +70,9 @@ class Model(ABC):
                 Cache.set_cached_result(message.body.content_hash, result)
             except Exception as e:
                 if isinstance(e, PrestoBaseException):
-                    return self.handle_fingerprinting_error(e, e.error_code)
+                    return self.handle_fingerprinting_error(e, e.error_code, {"message_body": message.body})
                 else:
-                    return self.handle_fingerprinting_error(e)
+                    return self.handle_fingerprinting_error(e, 500, {"message_body": message.body})
         return result
 
     def respond(self, messages: Union[List[schemas.Message], schemas.Message]) -> List[schemas.Message]:

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -69,10 +69,11 @@ class Model(ABC):
                 result = self.process(message)
                 Cache.set_cached_result(message.body.content_hash, result)
             except Exception as e:
+                import code;code.interact(local=dict(globals(), **locals())) 
                 if isinstance(e, PrestoBaseException):
-                    return self.handle_fingerprinting_error(e, e.error_code, {"message_body": message.body})
+                    return self.handle_fingerprinting_error(e, e.error_code, {"message_body": message.body.model_dump()})
                 else:
-                    return self.handle_fingerprinting_error(e, 500, {"message_body": message.body})
+                    return self.handle_fingerprinting_error(e, 500, {"message_body": message.body.model_dump()})
         return result
 
     def respond(self, messages: Union[List[schemas.Message], schemas.Message]) -> List[schemas.Message]:

--- a/lib/model/model.py
+++ b/lib/model/model.py
@@ -69,7 +69,6 @@ class Model(ABC):
                 result = self.process(message)
                 Cache.set_cached_result(message.body.content_hash, result)
             except Exception as e:
-                import code;code.interact(local=dict(globals(), **locals())) 
                 if isinstance(e, PrestoBaseException):
                     return self.handle_fingerprinting_error(e, e.error_code, {"message_body": message.body.model_dump()})
                 else:

--- a/lib/queue/queue.py
+++ b/lib/queue/queue.py
@@ -123,7 +123,7 @@ class Queue:
         Send a message to a specific queue.
         """
         queue = self.get_or_create_queue(queue_name)[0]
-        message_data = {"MessageBody": json.dumps(message.dict())}
+        message_data = {"MessageBody": json.dumps(message.model_dump())}
         if queue_name.endswith('.fifo'):
             message_data["MessageGroupId"] = message.body.id
         queue.send_message(**message_data)
@@ -182,7 +182,7 @@ class Queue:
         """
         Actual SQS logic for pushing a message to a queue
         """
-        message_data = {"MessageBody": json.dumps(message.dict())}
+        message_data = {"MessageBody": json.dumps(message.model_dump())}
         if queue_name.endswith('.fifo'):
             message_data["MessageGroupId"] = message.body.id
         self.find_queue_by_name(queue_name).send_message(**message_data)


### PR DESCRIPTION
## Description
We have some errors where we're attempting to vectorize texts where the "texts" are null. We have no provenance tracking for how these filtered into Presto. In order to debug this effectively, we need to know that info - and for many other errors that'll likely be the case as well. This packs in additional context to sentry captures for any fingerprinting process.

Reference: CV2-5789

## How has this been tested?
Not yet tested locally - we already have this pattern in place for a few cases so it _should_ just play nicely.

## Are there any external dependencies?
None, sentry I suppose, lol

## Have you considered secure coding practices when writing this code?
Nothing in particular here.
