### PR TITLE
[CV2-5925] standardize messages for logs

### DIFF
--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y jq
-        pip install awscli==1.29.59 botocore==1.31.59 boto3==1.28.58 ecs-deploy==1.14.0 --break-system-packages
+        snap install aws-cli --classic
     
     - name: Retrieve Presto test parameters from SSM
       id: get-ssm-params

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y jq
-        snap install aws-cli --classic
+        sudo snap install aws-cli --classic
     
     - name: Retrieve Presto test parameters from SSM
       id: get-ssm-params

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y jq
-        pip install awscli==1.29.59 botocore==1.31.58 boto3==1.28.58 ecs-deploy==1.14.0 --break-system-packages
+        pip install awscli==1.29.59 botocore==1.31.59 boto3==1.28.58 ecs-deploy==1.14.0 --break-system-packages
     
     - name: Retrieve Presto test parameters from SSM
       id: get-ssm-params

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -56,8 +56,8 @@ jobs:
     - name: Install AWS CLI and jq
       run: |
         sudo apt-get update
-        sudo apt-get install -y awscli 
         sudo apt-get install -y jq
+        pip install awscli==1.29.59 botocore==1.31.58 boto3==1.28.58 ecs-deploy==1.14.0 --break-system-packages
     
     - name: Retrieve Presto test parameters from SSM
       id: get-ssm-params

--- a/lib/queue/processor.py
+++ b/lib/queue/processor.py
@@ -6,7 +6,7 @@ import requests
 from lib import schemas
 from lib.logger import logger
 from lib.queue.queue import Queue
-
+from lib.sentry import capture_custom_message
 
 class QueueProcessor(Queue):
     @classmethod
@@ -68,9 +68,7 @@ class QueueProcessor(Queue):
                 # headers={"Content-Type": "application/json"},
             )
             if response.ok != True:
-                logger.error(f"Callback error responding to {callback_url} :{response}")
+                capture_custom_message("Callback response not ok", 'error', {"response": response, "callback_url": callback_url})
         except Exception as e:
             duration = (datetime.now() - start_time).total_seconds()
-            logger.error(
-                f"Callback fail! Failed with {e} on {callback_url} with message of {message}, duration was {duration}"
-            )
+            capture_custom_message("Presto callback failure", 'error', {"error": e, "callback_url": callback_url, "message": message, "duration": duration})

--- a/lib/queue/processor.py
+++ b/lib/queue/processor.py
@@ -68,7 +68,7 @@ class QueueProcessor(Queue):
                 # headers={"Content-Type": "application/json"},
             )
             if response.ok != True:
-                capture_custom_message("Callback response not ok", 'error', {"response": response, "callback_url": callback_url})
+                capture_custom_message(f"Callback response not ok: error code {response.status_code}", 'error', {"status_code": response.status_code, "response": response, "callback_url": callback_url})
         except Exception as e:
             duration = (datetime.now() - start_time).total_seconds()
             capture_custom_message("Presto callback failure", 'error', {"error": e, "callback_url": callback_url, "message": message, "duration": duration})

--- a/lib/queue/worker.py
+++ b/lib/queue/worker.py
@@ -149,7 +149,7 @@ class QueueWorker(Queue):
         Parameters:
         - error (Exception or str): The error to log, can be an Exception object or a string message.
         """
-        logger.error(error)
+        capture_custom_message(error, 'error')
 
     def delete_processed_messages(self, messages_with_queues: List[Tuple]):
         """

--- a/lib/sentry.py
+++ b/lib/sentry.py
@@ -1,15 +1,16 @@
 import os
 import sentry_sdk
 from lib.helpers import get_environment_setting
-
+DEPLOY_ENV = get_environment_setting("DEPLOY_ENV")
+SENTRY_DSN = get_environment_setting('sentry_sdk_dsn')
 sentry_sdk.init(
-    dsn=get_environment_setting('sentry_sdk_dsn'),
-    environment=get_environment_setting("DEPLOY_ENV"),
+    dsn=SENTRY_DSN,
+    environment=DEPLOY_ENV,
     traces_sample_rate=1.0,
 )
 
 def capture_custom_message(message, level='info', extra=None):
-    if get_environment_setting("DEPLOY_ENV") != 'local':
+    if DEPLOY_ENV and DEPLOY_ENV not in ['local', 'test']:
         with sentry_sdk.configure_scope() as scope:
             if extra:
                 for key, value in extra.items():

--- a/lib/sentry.py
+++ b/lib/sentry.py
@@ -9,8 +9,9 @@ sentry_sdk.init(
 )
 
 def capture_custom_message(message, level='info', extra=None):
-    with sentry_sdk.configure_scope() as scope:
-        if extra:
-            for key, value in extra.items():
-                scope.set_extra(key, value)
-        sentry_sdk.capture_message(message, level=level)
+    if get_environment_setting("DEPLOY_ENV") != 'local':
+        with sentry_sdk.configure_scope() as scope:
+            if extra:
+                for key, value in extra.items():
+                    scope.set_extra(key, value)
+            sentry_sdk.capture_message(message, level=level)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 transformers==4.38.0
-boto3==1.18.64
+boto3==1.18.64 --break-system-packages
 pyacoustid==1.2.2
 sentence-transformers==2.2.2
 tmkpy==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 transformers==4.38.0
-boto3==1.18.64 --break-system-packages
+boto3==1.18.64
 pyacoustid==1.2.2
 sentence-transformers==2.2.2
 tmkpy==0.1.1

--- a/test/lib/queue/test_processor.py
+++ b/test/lib/queue/test_processor.py
@@ -42,12 +42,13 @@ class TestQueueProcessor(unittest.TestCase):
         self.queue_processor.send_callback(message_body)
         mock_post.assert_called_once_with("http://example.com", timeout=30, json=message_body)
 
+    @patch('lib.sentry.capture_custom_message')
     @patch('lib.queue.processor.requests.post')
-    def test_send_callback_failure(self, mock_post):
+    def test_send_callback_failure(self, mock_post, mock_capture_custom_message):
         mock_post.side_effect = Exception("Request Failed!")
         message_body = {"body": {"callback_url": "http://example.com", "text": "This is a test", "id": 123, "result": {"hash_value": [1,2,3]}}, "model_name": "mean_tokens__Model"}
-        with self.assertLogs(level='ERROR') as cm:
-            self.queue_processor.send_callback(message_body)
+        mock_capture_custom_message.assert_called_once_with("Test error")
+        self.queue_processor.send_callback(message_body)
         self.assertIn("Failed with Request Failed! on http://example.com with message of", cm.output[0])
 
 if __name__ == '__main__':

--- a/test/lib/queue/test_processor.py
+++ b/test/lib/queue/test_processor.py
@@ -42,14 +42,13 @@ class TestQueueProcessor(unittest.TestCase):
         self.queue_processor.send_callback(message_body)
         mock_post.assert_called_once_with("http://example.com", timeout=30, json=message_body)
 
-    @patch('lib.sentry.capture_custom_message')
+    @patch('lib.queue.processor.capture_custom_message')
     @patch('lib.queue.processor.requests.post')
     def test_send_callback_failure(self, mock_post, mock_capture_custom_message):
         mock_post.side_effect = Exception("Request Failed!")
         message_body = {"body": {"callback_url": "http://example.com", "text": "This is a test", "id": 123, "result": {"hash_value": [1,2,3]}}, "model_name": "mean_tokens__Model"}
-        mock_capture_custom_message.assert_called_once_with("Test error")
         self.queue_processor.send_callback(message_body)
-        self.assertIn("Failed with Request Failed! on http://example.com with message of", cm.output[0])
+        mock_capture_custom_message.assert_called_once()
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/lib/queue/test_queue.py
+++ b/test/lib/queue/test_queue.py
@@ -235,10 +235,10 @@ class TestQueueWorker(unittest.TestCase):
         self.assertEqual(extracted_messages[1].body.text, "Test message 2")
         self.assertEqual(extracted_messages[0].model_name, "audio__Model")
 
-    @patch('lib.queue.worker.logger.error')
-    def test_log_and_handle_error(self, mock_logger_error):
+    @patch('lib.sentry.capture_custom_message')
+    def test_log_and_handle_error(self, mock_capture_custom_message):
         self.queue.log_and_handle_error("Test error")
-        mock_logger_error.assert_called_once_with("Test error")
+        mock_capture_custom_message.assert_called_once_with("Test error")
 
     @patch('lib.queue.worker.QueueWorker.delete_messages')
     def test_delete_processed_messages(self, mock_delete_messages):

--- a/test/lib/queue/test_queue.py
+++ b/test/lib/queue/test_queue.py
@@ -74,13 +74,13 @@ class TestQueueWorker(unittest.TestCase):
     def test_get_dead_letter_queue_name(self):
         self.assertEqual(self.queue.get_dead_letter_queue_name().replace(".fifo", ""), (self.queue.get_input_queue_name()+'_dlq').replace(".fifo", ""))
 
-    @patch('lib.queue.worker.QueueWorker.log_and_handle_error')
+    @patch('lib.queue.worker.capture_custom_message')
     @patch('lib.queue.worker.time.time', side_effect=[0, 1])
-    def test_execute_with_timeout_failure(self, mock_time, mock_log_error):
+    def test_execute_with_timeout_failure(self, mock_time, mock_capture_custom_message):
         responses, success = self.queue.execute_with_timeout(MockModelTimeout(), [], timeout_seconds=1)
         self.assertEqual(responses, [])
         self.assertFalse(success)
-        mock_log_error.assert_called_once_with("Model respond timeout exceeded.")
+        mock_capture_custom_message.assert_called_once()
 
     @patch('lib.queue.worker.QueueWorker.log_and_handle_error')
     @patch('lib.queue.worker.time.time', side_effect=[0, 0.5])
@@ -235,10 +235,10 @@ class TestQueueWorker(unittest.TestCase):
         self.assertEqual(extracted_messages[1].body.text, "Test message 2")
         self.assertEqual(extracted_messages[0].model_name, "audio__Model")
 
-    @patch('lib.sentry.capture_custom_message')
+    @patch('lib.queue.worker.capture_custom_message')
     def test_log_and_handle_error(self, mock_capture_custom_message):
         self.queue.log_and_handle_error("Test error")
-        mock_capture_custom_message.assert_called_once_with("Test error")
+        mock_capture_custom_message.assert_called_once()
 
     @patch('lib.queue.worker.QueueWorker.delete_messages')
     def test_delete_processed_messages(self, mock_delete_messages):


### PR DESCRIPTION
## Description
When you run `logger.error` in the context of an exception, that percolates to sentry as an error with whatever the `logger.error` text is. This converts those cases to use our capture message format instead to sync them all up.

Reference: CV2-5925

## How has this been tested?
Not yet tested locally, CI should discover any issues here.

## Are there any external dependencies?
None

## Have you considered secure coding practices when writing this code?
Not relevant
