### PR TITLE
CV2-6509: Fix Docker build by updating chromaprint source and fasttext dependency

### DIFF
--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -1,9 +1,7 @@
 name: Build and Run Integration Test
 
 on:
-  push:
-    branches:
-    - '**'
+  pull_request
 
 permissions:
   id-token: write

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -1,7 +1,9 @@
 name: Build and Run Integration Test
 
 on:
-  pull_request
+  push:
+    branches:
+    - '**'
 
 permissions:
   id-token: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN ln -s /usr/bin/ffmpeg /usr/local/bin/ffmpeg
 
 COPY ./threatexchange /app/threatexchange
 RUN make -C /app/threatexchange/tmk/cpp
-RUN git clone https://github.com/meedan/chromaprint.git
+RUN git clone https://github.com/acoustid/chromaprint.git
 RUN cd chromaprint && cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TOOLS=ON .
 RUN cd chromaprint && make
 RUN cd chromaprint && make install

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ fastapi==0.109.1
 uvicorn[standard]==0.19.0
 httpx==0.23.1
 huggingface-hub==0.19.3
-fasttext==0.9.2
+fasttext-wheel==0.9.2
 langcodes==3.3.0 
 requests==2.32.2
 pytest==7.4.0


### PR DESCRIPTION
## Description

- [ ] Updated `git clone` to use the official `acoustid/chromaprint` repository instead of the outdated fork.
- [ ] Replaced fasttext with fasttext-wheel to ensure compatibility and easier installation.

Reference: CV2-6509

## How has this been tested?

- [ ] Ran the build successfully.
- [ ] Verified similarity tests on Check Web.  https://github.com/meedan/check-web/actions/runs/17083624709/job/48443163633 | https://github.com/meedan/check-web/actions/runs/17083624709/job/48446243366
