### PR TITLE
Invoke sysops deployment with image tag for Live updates.

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -81,7 +81,7 @@ jobs:
 
     - name: Kick off Terraform QA deploy in sysops/
       id: sysops-deploy-qa
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main')
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/master')
       run: |
         curl --fail-with-body \
           -X POST \

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -79,9 +79,9 @@ jobs:
           --tag $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH \
           --file ./Dockerfile ./
 
-    - name: Kick off Terraform deploy in sysops/
-      id: sysops-deploy
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/master')
+    - name: Kick off Terraform QA deploy in sysops/
+      id: sysops-deploy-qa
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main')
       run: |
         curl --fail-with-body \
           -X POST \
@@ -90,18 +90,19 @@ jobs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/meedan/sysops/actions/workflows/deploy_${{ github.event.repository.name }}.yml/dispatches \
           -d '{"ref": "master", "inputs": {"git_sha": "${{ github.sha }}", "type": "push"}}'
-
-    - name: Kick off Terraform deploy in sysops/
+      
+    - name: Kick off Terraform Live deploy in sysops/
       id: sysops-deploy-live
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       run: |
+        RELEASE_TAG=$(echo "${GITHUB_REF#refs/*/}" | sed 's/.*\///')
         curl --fail-with-body \
           -X POST \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ secrets.SYSOPS_RW_GITHUB_TOKEN }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/meedan/sysops/actions/workflows/deploy_${{ github.event.repository.name }}.yml/dispatches \
-          -d '{"ref": "master", "inputs": {"git_sha": "${{ github.sha }}", "type": "tag"}}'
+          -d '{"ref": "master", "inputs": {"image_tag": "'$RELEASE_TAG'", "type": "tag"}}'
 
     - name: Reset cache
       id: reset-cache


### PR DESCRIPTION
## Description

This change adds support for deployment workflow invocation with an image_tag input used for Live cluster updates. This resolves an error where git_sha based deployments lacked sufficient lifecycle policy in ECR to keep services running during ongoing development and CI/CD builds.

See also: https://meedan.atlassian.net/browse/CV2-6664

## Have you considered secure coding practices when writing this code?

Yes, no security concerns with this change.